### PR TITLE
feat: add search filters and pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,21 @@ npm run preview
 - Los íconos provienen de [@heroicons/react](https://github.com/tailwindlabs/heroicons) y se utilizan para comunicar acciones y metadatos de forma visual.
 - Cada tarjeta de post cuenta con imágenes de Unsplash adaptativas y animaciones suaves para mejorar la interacción.
 
+## Búsqueda, filtros y paginación
+
+- El listado de posts admite búsqueda instantánea con [Fuse.js](https://fusejs.io/) sobre el título, resumen, contenido y etiquetas.
+- Puedes combinar la búsqueda con un filtro multiselección por etiquetas; los cambios se reflejan en la URL (`?q=`, `&tags=` y `&page=`) y se recuerdan automáticamente en `localStorage` (`blog:list:state`).
+- Los atajos `/` (enfocar) y `Esc` (limpiar y desenfocar) permiten interactuar con el buscador sin usar el mouse.
+- La paginación muestra 6 entradas por página e incluye navegación anterior/siguiente con mantenimiento del estado entre recargas.
+
+### Pruebas manuales recomendadas
+
+1. Buscar por palabras específicas del contenido y validar que los resultados se actualizan al escribir.
+2. Seleccionar varias etiquetas, comprobar que solo se muestran los posts relacionados y que la URL incluye `tags=`.
+3. Recargar la página y verificar que se conserva la última búsqueda, filtros y página activa.
+4. Cambiar de página y usar los botones Atrás/Adelante del navegador para confirmar que el estado se sincroniza correctamente.
+5. Forzar una búsqueda sin resultados para visualizar el estado vacío y restablecer filtros desde el botón disponible.
+
 ## Licencia
 
 Este proyecto se distribuye bajo la licencia MIT. Siéntete libre de adaptarlo a tus necesidades.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@heroicons/react": "^2.2.0",
         "flowbite": "^2.3.0",
         "flowbite-react": "^0.7.5",
+        "fuse.js": "^7.1.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.22.3"
@@ -1944,6 +1945,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fuse.js": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.1.0.tgz",
+      "integrity": "sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/gensync": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@heroicons/react": "^2.2.0",
     "flowbite": "^2.3.0",
     "flowbite-react": "^0.7.5",
+    "fuse.js": "^7.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.22.3"

--- a/src/components/EmptyState.jsx
+++ b/src/components/EmptyState.jsx
@@ -1,0 +1,24 @@
+import { FaceFrownIcon } from '@heroicons/react/24/outline';
+
+function EmptyState({ onReset }) {
+  return (
+    <div className="flex flex-col items-center justify-center gap-4 rounded-3xl border border-dashed border-slate-300 bg-white/80 p-10 text-center shadow-sm transition-colors duration-300 dark:border-slate-700 dark:bg-slate-900/60">
+      <FaceFrownIcon className="h-12 w-12 text-slate-400 dark:text-slate-500" aria-hidden="true" />
+      <div className="space-y-2">
+        <h3 className="text-xl font-semibold text-slate-900 dark:text-white">No encontramos resultados</h3>
+        <p className="text-sm text-slate-500 dark:text-slate-400">
+          Ajusta tu búsqueda o prueba con otras etiquetas para descubrir nuevas publicaciones.
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={onReset}
+        className="inline-flex items-center gap-2 rounded-full border border-sky-500/40 bg-sky-50 px-5 py-2 text-sm font-semibold text-sky-600 transition duration-200 hover:-translate-y-0.5 hover:bg-sky-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 dark:border-sky-400/40 dark:bg-sky-900/40 dark:text-sky-200 dark:hover:bg-sky-900/60 dark:focus-visible:ring-offset-slate-900"
+      >
+        Limpiar filtros
+      </button>
+    </div>
+  );
+}
+
+export default EmptyState;

--- a/src/components/Pagination.jsx
+++ b/src/components/Pagination.jsx
@@ -1,0 +1,63 @@
+import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/react/24/outline';
+
+function Pagination({ currentPage = 1, totalPages = 1, onPageChange }) {
+  if (totalPages <= 1) {
+    return null;
+  }
+
+  const goToPage = (page) => {
+    if (page < 1 || page > totalPages || page === currentPage) {
+      return;
+    }
+    onPageChange?.(page);
+  };
+
+  const pages = Array.from({ length: totalPages }, (_, index) => index + 1);
+
+  return (
+    <nav className="flex items-center justify-center" aria-label="Paginación de posts">
+      <div className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white/80 p-2 shadow-sm transition-colors duration-300 dark:border-slate-800 dark:bg-slate-900/60">
+        <button
+          type="button"
+          onClick={() => goToPage(currentPage - 1)}
+          disabled={currentPage === 1}
+          className="inline-flex items-center gap-1 rounded-full px-3 py-2 text-sm font-medium text-slate-600 transition duration-200 hover:bg-slate-100 hover:text-slate-900 disabled:pointer-events-none disabled:opacity-40 dark:text-slate-300 dark:hover:bg-slate-800"
+        >
+          <ChevronLeftIcon className="h-4 w-4" aria-hidden="true" />
+          Anterior
+        </button>
+        <div className="flex items-center gap-1">
+          {pages.map((page) => {
+            const isActive = page === currentPage;
+            return (
+              <button
+                key={page}
+                type="button"
+                onClick={() => goToPage(page)}
+                className={`inline-flex h-9 w-9 items-center justify-center rounded-full text-sm font-semibold transition duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-900 ${
+                  isActive
+                    ? 'bg-sky-600 text-white shadow-sm hover:bg-sky-600/90'
+                    : 'text-slate-600 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800'
+                }`}
+                aria-current={isActive ? 'page' : undefined}
+              >
+                {page}
+              </button>
+            );
+          })}
+        </div>
+        <button
+          type="button"
+          onClick={() => goToPage(currentPage + 1)}
+          disabled={currentPage === totalPages}
+          className="inline-flex items-center gap-1 rounded-full px-3 py-2 text-sm font-medium text-slate-600 transition duration-200 hover:bg-slate-100 hover:text-slate-900 disabled:pointer-events-none disabled:opacity-40 dark:text-slate-300 dark:hover:bg-slate-800"
+        >
+          Siguiente
+          <ChevronRightIcon className="h-4 w-4" aria-hidden="true" />
+        </button>
+      </div>
+    </nav>
+  );
+}
+
+export default Pagination;

--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -1,0 +1,51 @@
+import { forwardRef } from 'react';
+import { MagnifyingGlassIcon, XMarkIcon } from '@heroicons/react/24/outline';
+
+const SearchBar = forwardRef(
+  (
+    {
+      value,
+      onChange,
+      onClear,
+      placeholder = 'Buscar posts… (/)',
+      label = 'Buscar posts'
+    },
+    ref
+  ) => {
+    return (
+      <div className="w-full">
+        <label htmlFor="blog-search" className="sr-only">
+          {label}
+        </label>
+        <div className="relative">
+          <MagnifyingGlassIcon
+            className="pointer-events-none absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-slate-400"
+            aria-hidden="true"
+          />
+          <input
+            id="blog-search"
+            ref={ref}
+            type="search"
+            value={value}
+            onChange={(event) => onChange?.(event.target.value)}
+            placeholder={placeholder}
+            autoComplete="off"
+            className="w-full rounded-2xl border border-slate-200 bg-white/90 py-3 pl-11 pr-12 text-base text-slate-700 shadow-sm transition duration-300 placeholder:text-slate-400 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-2 dark:border-slate-700 dark:bg-slate-900/70 dark:text-slate-200 dark:placeholder:text-slate-500 dark:focus:ring-offset-slate-900"
+          />
+          {value && value.length > 0 ? (
+            <button
+              type="button"
+              onClick={onClear}
+              className="absolute right-2 top-1/2 inline-flex h-8 w-8 -translate-y-1/2 items-center justify-center rounded-full text-slate-400 transition duration-200 hover:bg-slate-100 hover:text-slate-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 dark:text-slate-500 dark:hover:bg-slate-800 dark:hover:text-slate-300 dark:focus-visible:ring-offset-slate-900"
+              aria-label="Limpiar búsqueda"
+            >
+              <XMarkIcon className="h-5 w-5" aria-hidden="true" />
+            </button>
+          ) : null}
+        </div>
+      </div>
+    );
+  }
+);
+
+export default SearchBar;

--- a/src/components/TagFilter.jsx
+++ b/src/components/TagFilter.jsx
@@ -1,0 +1,57 @@
+import { TagIcon } from '@heroicons/react/24/outline';
+
+function TagFilter({ options = [], selectedTags = [], onToggle, onClear }) {
+  if (!options.length) {
+    return null;
+  }
+
+  const isSelected = (value) => selectedTags.includes(value);
+
+  return (
+    <section
+      aria-labelledby="tag-filter-title"
+      className="rounded-3xl border border-slate-200 bg-white/80 p-6 shadow-sm transition-colors duration-300 dark:border-slate-800 dark:bg-slate-900/60"
+    >
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div className="inline-flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+          <TagIcon className="h-5 w-5 text-sky-500 dark:text-sky-300" aria-hidden="true" />
+          <span id="tag-filter-title">Filtrar por etiquetas</span>
+        </div>
+        {selectedTags.length > 0 ? (
+          <button
+            type="button"
+            onClick={onClear}
+            className="text-sm font-medium text-sky-600 transition duration-200 hover:text-sky-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 dark:text-sky-300 dark:hover:text-sky-200 dark:focus-visible:ring-offset-slate-900"
+          >
+            Limpiar filtros
+          </button>
+        ) : null}
+      </div>
+      <div className="mt-4 flex flex-wrap gap-3">
+        {options.map((tag) => {
+          const active = isSelected(tag.value);
+          return (
+            <button
+              key={tag.value}
+              type="button"
+              onClick={() => onToggle?.(tag.value)}
+              className={`group inline-flex items-center gap-2 rounded-full border px-4 py-2 text-sm font-medium transition duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-900 ${
+                active
+                  ? 'border-sky-500/60 bg-sky-100 text-sky-700 shadow-sm dark:border-sky-400/60 dark:bg-sky-900/50 dark:text-sky-200'
+                  : 'border-slate-200 bg-white/80 text-slate-600 hover:-translate-y-0.5 hover:border-sky-400 hover:text-sky-600 dark:border-slate-700 dark:bg-slate-800/70 dark:text-slate-300 dark:hover:border-sky-400/60 dark:hover:text-sky-200'
+              }`}
+              aria-pressed={active}
+            >
+              <span>#{tag.label}</span>
+              <span className="rounded-full bg-slate-100 px-2 py-0.5 text-xs font-semibold text-slate-500 transition duration-200 group-hover:bg-sky-100 group-hover:text-sky-600 dark:bg-slate-800 dark:text-slate-400 dark:group-hover:bg-sky-900/60 dark:group-hover:text-sky-200">
+                {tag.count}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+export default TagFilter;

--- a/src/data/posts.json
+++ b/src/data/posts.json
@@ -11,6 +11,7 @@
       "También revisamos el ecosistema que rodea a React y cómo herramientas como Vite, Tailwind CSS y Flowbite pueden ayudarte a crear experiencias ricas y eficientes."
     ],
     "etiquetas": ["React", "Frontend", "JavaScript"],
+    "tags": ["react", "frontend", "javascript"],
     "imagen": "https://images.unsplash.com/photo-1523475472560-d2df97ec485c?auto=format&fit=crop&w=1200&q=80",
     "imagenAlt": "Código de React en una pantalla con iluminación tenue"
   },
@@ -26,6 +27,7 @@
       "Para complementar, utilizamos componentes de Flowbite que aceleran el desarrollo y ofrecen una base visual bien definida."
     ],
     "etiquetas": ["Tailwind", "Diseño", "Productividad"],
+    "tags": ["tailwind", "diseno", "productividad"],
     "imagen": "https://images.unsplash.com/photo-1523475472560-5a6bc78c15a0?auto=format&fit=crop&w=1200&q=80",
     "imagenAlt": "Persona diseñando componentes en un tablero con notas adhesivas"
   },
@@ -41,6 +43,7 @@
       "Aprenderás a crear experiencias fluidas para tus usuarios, incluyendo navegación programática y enlaces accesibles."
     ],
     "etiquetas": ["React Router", "Routing", "Buenas prácticas"],
+    "tags": ["react-router", "routing", "buenas-practicas"],
     "imagen": "https://images.unsplash.com/photo-1516321497487-e288fb19713f?auto=format&fit=crop&w=1200&q=80",
     "imagenAlt": "Panel de control con múltiples caminos iluminados"
   }

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,14 +1,339 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Card, Badge } from 'flowbite-react';
-import { Link } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 import {
   ArrowRightIcon,
   ChatBubbleLeftEllipsisIcon,
   ClockIcon,
   UserCircleIcon
 } from '@heroicons/react/24/outline';
+import Fuse from 'fuse.js';
+import SearchBar from '../components/SearchBar';
+import TagFilter from '../components/TagFilter';
+import Pagination from '../components/Pagination';
+import EmptyState from '../components/EmptyState';
 import posts from '../data/posts.json';
 
+const POSTS_PER_PAGE = 6;
+const STORAGE_KEY = 'blog:list:state';
+
+const parseSearchParams = (searchString) => {
+  const params = new URLSearchParams(searchString);
+  const rawQuery = params.get('q') ?? '';
+  const tagsValue = params.get('tags');
+  const tagList = tagsValue ? tagsValue.split(',').filter(Boolean) : [];
+  const pageParam = params.get('page');
+  const parsedPage = pageParam ? Number.parseInt(pageParam, 10) : undefined;
+
+  return {
+    hasQuery: params.has('q'),
+    query: rawQuery,
+    hasTags: params.has('tags'),
+    tags: tagList,
+    hasPage: params.has('page'),
+    page: !Number.isNaN(parsedPage) && parsedPage && parsedPage > 0 ? parsedPage : 1
+  };
+};
+
+const readStoredState = () => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return null;
+    }
+    const parsed = JSON.parse(raw);
+    const q = typeof parsed?.q === 'string' ? parsed.q : '';
+    const tags = Array.isArray(parsed?.tags) ? parsed.tags.filter((tag) => typeof tag === 'string') : [];
+    const page = Number.isInteger(parsed?.page) && parsed.page > 0 ? parsed.page : 1;
+    return { q, tags, page };
+  } catch (error) {
+    return null;
+  }
+};
+
 function Home() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const searchInputRef = useRef(null);
+
+  const availableTagOptions = useMemo(() => {
+    const collator = new Intl.Collator('es', { sensitivity: 'base' });
+    const accumulator = new Map();
+
+    posts.forEach((post) => {
+      post.tags.forEach((value, index) => {
+        const label = post.etiquetas?.[index] ?? value;
+        const existing = accumulator.get(value);
+        if (existing) {
+          existing.count += 1;
+        } else {
+          accumulator.set(value, { value, label, count: 1 });
+        }
+      });
+    });
+
+    return Array.from(accumulator.values()).sort((a, b) => collator.compare(a.label, b.label));
+  }, []);
+
+  const availableTagSet = useMemo(
+    () => new Set(availableTagOptions.map((tag) => tag.value)),
+    [availableTagOptions]
+  );
+
+  const sanitizeTags = useCallback(
+    (tags = []) => {
+      const unique = new Set();
+      tags.forEach((tag) => {
+        if (typeof tag === 'string' && availableTagSet.has(tag)) {
+          unique.add(tag);
+        }
+      });
+      return Array.from(unique).sort((a, b) => a.localeCompare(b, 'es', { sensitivity: 'base' }));
+    },
+    [availableTagSet]
+  );
+
+  const storedState = useMemo(() => readStoredState(), []);
+  const paramsState = useMemo(() => parseSearchParams(location.search), [location.search]);
+
+  const [searchQuery, setSearchQuery] = useState(() =>
+    paramsState.hasQuery ? paramsState.query : storedState?.q ?? ''
+  );
+  const [selectedTags, setSelectedTags] = useState(() =>
+    paramsState.hasTags ? sanitizeTags(paramsState.tags) : sanitizeTags(storedState?.tags ?? [])
+  );
+  const [currentPage, setCurrentPage] = useState(() =>
+    paramsState.hasPage ? paramsState.page : storedState?.page ?? 1
+  );
+
+  const syncUrl = useCallback(
+    (state, replace = false) => {
+      const params = new URLSearchParams();
+      if (state.q) {
+        params.set('q', state.q);
+      }
+      if (state.tags?.length) {
+        params.set('tags', state.tags.join(','));
+      }
+      if (state.page && state.page > 1) {
+        params.set('page', String(state.page));
+      }
+
+      const nextSearch = params.toString();
+      const currentSearch = location.search.startsWith('?')
+        ? location.search.slice(1)
+        : location.search;
+
+      if (nextSearch === currentSearch) {
+        return;
+      }
+
+      navigate(
+        {
+          pathname: location.pathname,
+          search: nextSearch ? `?${nextSearch}` : ''
+        },
+        { replace }
+      );
+    },
+    [navigate, location.pathname, location.search]
+  );
+
+  const isFirstSync = useRef(true);
+
+  useEffect(() => {
+    const parsed = parseSearchParams(location.search);
+    const hasAnyParam = parsed.hasQuery || parsed.hasTags || parsed.hasPage;
+
+    if (isFirstSync.current) {
+      isFirstSync.current = false;
+      if (!hasAnyParam && storedState) {
+        const normalizedTags = sanitizeTags(storedState.tags ?? []);
+        setSearchQuery(storedState.q ?? '');
+        setSelectedTags(normalizedTags);
+        setCurrentPage(storedState.page ?? 1);
+        syncUrl(
+          {
+            q: (storedState.q ?? '').trim(),
+            tags: normalizedTags,
+            page: storedState.page ?? 1
+          },
+          true
+        );
+        return;
+      }
+    }
+
+    setSearchQuery(parsed.hasQuery ? parsed.query : '');
+    setSelectedTags(parsed.hasTags ? sanitizeTags(parsed.tags) : []);
+    setCurrentPage(parsed.hasPage ? parsed.page : 1);
+  }, [location.search, sanitizeTags, storedState, syncUrl]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const stateToStore = {
+      q: searchQuery,
+      tags: selectedTags,
+      page: currentPage
+    };
+
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(stateToStore));
+  }, [searchQuery, selectedTags, currentPage]);
+
+  useEffect(() => {
+    const trimmedQuery = searchQuery.trim();
+    syncUrl({ q: trimmedQuery, tags: selectedTags, page: currentPage });
+  }, [searchQuery, selectedTags, currentPage, syncUrl]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const handleKeyDown = (event) => {
+      if (event.key === '/' && !event.defaultPrevented) {
+        const target = event.target;
+        const isFormElement =
+          target instanceof HTMLInputElement ||
+          target instanceof HTMLTextAreaElement ||
+          (target && target.isContentEditable);
+
+        if (!isFormElement && !event.ctrlKey && !event.metaKey && !event.altKey) {
+          event.preventDefault();
+          searchInputRef.current?.focus();
+          searchInputRef.current?.select();
+        }
+      }
+
+      if (event.key === 'Escape') {
+        if (document.activeElement === searchInputRef.current || searchQuery) {
+          event.preventDefault();
+          if (searchQuery) {
+            setSearchQuery('');
+            setCurrentPage(1);
+          }
+          if (document.activeElement === searchInputRef.current) {
+            searchInputRef.current.blur();
+          }
+        }
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [searchQuery]);
+
+  const filteredByTags = useMemo(() => {
+    if (!selectedTags.length) {
+      return posts;
+    }
+
+    return posts.filter((post) => selectedTags.every((tag) => post.tags.includes(tag)));
+  }, [selectedTags]);
+
+  const fuseDataset = useMemo(
+    () =>
+      filteredByTags.map((post) => ({
+        ...post,
+        title: post.titulo,
+        excerpt: post.resumen,
+        content: post.contenido.join(' '),
+        tags: [...post.tags, ...(post.etiquetas ?? [])]
+      })),
+    [filteredByTags]
+  );
+
+  const fuse = useMemo(
+    () =>
+      new Fuse(fuseDataset, {
+        keys: [
+          { name: 'title', weight: 0.4 },
+          { name: 'excerpt', weight: 0.3 },
+          { name: 'content', weight: 0.2 },
+          { name: 'tags', weight: 0.1 }
+        ],
+        threshold: 0.35,
+        ignoreLocation: true,
+        includeScore: true
+      }),
+    [fuseDataset]
+  );
+
+  const trimmedQuery = searchQuery.trim();
+
+  const searchedPosts = useMemo(() => {
+    if (!trimmedQuery) {
+      return filteredByTags;
+    }
+
+    return fuse.search(trimmedQuery).map((result) => result.item);
+  }, [filteredByTags, fuse, trimmedQuery]);
+
+  const resultsCount = searchedPosts.length;
+  const totalPages = Math.max(1, Math.ceil(resultsCount / POSTS_PER_PAGE));
+
+  useEffect(() => {
+    if (currentPage > totalPages) {
+      setCurrentPage(totalPages);
+    }
+  }, [currentPage, totalPages]);
+
+  const paginatedPosts = useMemo(() => {
+    const startIndex = (currentPage - 1) * POSTS_PER_PAGE;
+    return searchedPosts.slice(startIndex, startIndex + POSTS_PER_PAGE);
+  }, [searchedPosts, currentPage]);
+
+  const resultsLabel = `${resultsCount} ${resultsCount === 1 ? 'resultado' : 'resultados'}`;
+
+  const handleSearchChange = (value) => {
+    setSearchQuery(value);
+    setCurrentPage(1);
+  };
+
+  const handleClearSearch = () => {
+    setSearchQuery('');
+    setCurrentPage(1);
+    searchInputRef.current?.focus();
+  };
+
+  const handleToggleTag = (value) => {
+    setSelectedTags((prev) => {
+      const next = new Set(prev);
+      if (next.has(value)) {
+        next.delete(value);
+      } else if (availableTagSet.has(value)) {
+        next.add(value);
+      }
+      return Array.from(next).sort((a, b) => a.localeCompare(b, 'es', { sensitivity: 'base' }));
+    });
+    setCurrentPage(1);
+  };
+
+  const handleClearTags = () => {
+    setSelectedTags([]);
+    setCurrentPage(1);
+  };
+
+  const handleResetAll = () => {
+    setSearchQuery('');
+    setSelectedTags([]);
+    setCurrentPage(1);
+    searchInputRef.current?.focus();
+  };
+
+  const handlePageChange = (page) => {
+    setCurrentPage(page);
+  };
+
   return (
     <section className="space-y-12">
       <header className="space-y-4 text-center">
@@ -23,52 +348,104 @@ function Home() {
         </p>
       </header>
 
-      <div className="grid gap-8 md:grid-cols-2">
-        {posts.map((post) => (
-          <Card
-            key={post.id}
-            imgAlt={post.imagenAlt}
-            imgSrc={post.imagen}
-            className="flex h-full flex-col justify-between overflow-hidden border border-slate-200 bg-white/90 shadow-sm transition duration-300 hover:-translate-y-1 hover:shadow-2xl hover:shadow-sky-500/10 dark:border-slate-800 dark:bg-slate-900/70 dark:hover:shadow-sky-400/10"
-          >
-            <div className="space-y-3">
-              <div className="flex flex-wrap gap-2">
-                {post.etiquetas.map((tag) => (
-                  <Badge key={tag} color="info" className="bg-sky-100 text-sky-700 dark:bg-sky-900/60 dark:text-sky-200">
-                    {tag}
-                  </Badge>
-                ))}
-              </div>
-              <h2 className="text-2xl font-semibold text-slate-900 transition-colors duration-300 dark:text-white">
-                {post.titulo}
-              </h2>
-              <p className="flex flex-wrap items-center gap-4 text-sm text-slate-500 dark:text-slate-400">
-                <span className="inline-flex items-center gap-1">
-                  <UserCircleIcon className="h-4 w-4" aria-hidden="true" />
-                  {post.autor}
-                </span>
-                <span className="inline-flex items-center gap-1">
-                  <ClockIcon className="h-4 w-4" aria-hidden="true" />
-                  {new Date(post.fecha).toLocaleDateString('es-ES', { dateStyle: 'long' })}
-                </span>
-              </p>
-              <p className="text-base text-slate-600 dark:text-slate-300">{post.resumen}</p>
-            </div>
-            <div className="pt-4">
-              <Link
-                to={`/post/${post.id}`}
-                className="inline-flex items-center gap-2 text-sm font-semibold text-sky-600 transition duration-300 hover:gap-3 hover:text-sky-500 dark:text-sky-300 dark:hover:text-sky-200"
-              >
-                Leer artículo completo
-                <ArrowRightIcon className="h-4 w-4" aria-hidden="true" />
-              </Link>
-            </div>
-          </Card>
-        ))}
+      <div className="space-y-6">
+        <div className="space-y-3">
+          <SearchBar
+            ref={searchInputRef}
+            value={searchQuery}
+            onChange={handleSearchChange}
+            onClear={handleClearSearch}
+          />
+          <div className="flex flex-wrap items-center justify-between gap-3 text-sm text-slate-500 dark:text-slate-400">
+            <p className="font-medium text-slate-600 dark:text-slate-300">{resultsLabel}</p>
+            <p className="inline-flex items-center gap-2">
+              <span className="hidden sm:inline">Atajos:</span>
+              <span className="inline-flex items-center gap-1">
+                <kbd className="rounded-md border border-slate-300 bg-white px-2 py-0.5 text-xs font-semibold text-slate-600 shadow-sm dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200">
+                  /
+                </kbd>
+                enfocar
+              </span>
+              <span className="inline-flex items-center gap-1">
+                <kbd className="rounded-md border border-slate-300 bg-white px-2 py-0.5 text-xs font-semibold text-slate-600 shadow-sm dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200">
+                  Esc
+                </kbd>
+                limpiar
+              </span>
+            </p>
+          </div>
+        </div>
+
+        <TagFilter
+          options={availableTagOptions}
+          selectedTags={selectedTags}
+          onToggle={handleToggleTag}
+          onClear={handleClearTags}
+        />
       </div>
 
-      <section id="acerca" className="rounded-3xl border border-slate-200 bg-white/80 p-8 shadow-sm transition-colors duration-300 dark:border-slate-800 dark:bg-slate-900/60">
-        <h2 className="text-2xl font-semibold text-slate-900 transition-colors duration-300 dark:text-white">Sobre este blog</h2>
+      {paginatedPosts.length > 0 ? (
+        <>
+          <div className="grid gap-8 md:grid-cols-2">
+            {paginatedPosts.map((post) => (
+              <Card
+                key={post.id}
+                imgAlt={post.imagenAlt}
+                imgSrc={post.imagen}
+                className="flex h-full flex-col justify-between overflow-hidden border border-slate-200 bg-white/90 shadow-sm transition duration-300 hover:-translate-y-1 hover:shadow-2xl hover:shadow-sky-500/10 dark:border-slate-800 dark:bg-slate-900/70 dark:hover:shadow-sky-400/10"
+              >
+                <div className="space-y-3">
+                  <div className="flex flex-wrap gap-2">
+                    {post.etiquetas.map((tag) => (
+                      <Badge
+                        key={tag}
+                        color="info"
+                        className="bg-sky-100 text-sky-700 dark:bg-sky-900/60 dark:text-sky-200"
+                      >
+                        {tag}
+                      </Badge>
+                    ))}
+                  </div>
+                  <h2 className="text-2xl font-semibold text-slate-900 transition-colors duration-300 dark:text-white">
+                    {post.titulo}
+                  </h2>
+                  <p className="flex flex-wrap items-center gap-4 text-sm text-slate-500 dark:text-slate-400">
+                    <span className="inline-flex items-center gap-1">
+                      <UserCircleIcon className="h-4 w-4" aria-hidden="true" />
+                      {post.autor}
+                    </span>
+                    <span className="inline-flex items-center gap-1">
+                      <ClockIcon className="h-4 w-4" aria-hidden="true" />
+                      {new Date(post.fecha).toLocaleDateString('es-ES', { dateStyle: 'long' })}
+                    </span>
+                  </p>
+                  <p className="text-base text-slate-600 dark:text-slate-300">{post.resumen}</p>
+                </div>
+                <div className="pt-4">
+                  <Link
+                    to={`/post/${post.id}`}
+                    className="inline-flex items-center gap-2 text-sm font-semibold text-sky-600 transition duration-300 hover:gap-3 hover:text-sky-500 dark:text-sky-300 dark:hover:text-sky-200"
+                  >
+                    Leer artículo completo
+                    <ArrowRightIcon className="h-4 w-4" aria-hidden="true" />
+                  </Link>
+                </div>
+              </Card>
+            ))}
+          </div>
+          <Pagination currentPage={currentPage} totalPages={totalPages} onPageChange={handlePageChange} />
+        </>
+      ) : (
+        <EmptyState onReset={handleResetAll} />
+      )}
+
+      <section
+        id="acerca"
+        className="rounded-3xl border border-slate-200 bg-white/80 p-8 shadow-sm transition-colors duration-300 dark:border-slate-800 dark:bg-slate-900/60"
+      >
+        <h2 className="text-2xl font-semibold text-slate-900 transition-colors duration-300 dark:text-white">
+          Sobre este blog
+        </h2>
         <p className="mt-3 text-slate-600 dark:text-slate-300">
           Este proyecto demuestra cómo combinar React con Tailwind CSS, Flowbite y React Router para construir un blog estático moderno. Utiliza datos locales en formato JSON y está preparado para desplegarse automáticamente en GitHub Pages mediante GitHub Actions.
         </p>


### PR DESCRIPTION
## Summary
- add instant search, tag filtering, pagination, and empty state components to the home page
- persist list state via URL parameters and localStorage while enriching post data with tag metadata
- document the search, filters, pagination workflow and manual tests in the README

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f1e957fdc8832794d63d65b3a07da4