### PR TITLE
Add postgres network alias for backend connectivity

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -10,6 +10,10 @@ services:
       POSTGRES_PASSWORD: "${POSTGRES_PASSWORD}"
     volumes:
       - pgdata:/var/lib/postgresql/data
+    networks:
+      default:
+        aliases:
+          - posgres
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres} -d ${POSTGRES_DB:-postgres}"]
       interval: 10s


### PR DESCRIPTION
## Summary
- add a network alias `posgres` to the postgres service so the backend container can resolve the database host

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f2aa847bbc832780977d8b9603af24