### PR TITLE
Add backend API tests and document testing workflow

### DIFF
--- a/backend/blog/tests.py
+++ b/backend/blog/tests.py
@@ -1,3 +1,73 @@
-from django.test import TestCase
+"""API tests for the blog application."""
+from __future__ import annotations
 
-# Create your tests here.
+from datetime import date
+
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from .models import Post, Tag
+
+
+class PostAPITestCase(APITestCase):
+    """Validate the main behaviours of the public post API."""
+
+    def setUp(self) -> None:
+        self.list_url = reverse("post-list")
+
+    def test_list_returns_existing_post(self) -> None:
+        """The list endpoint must return the stored posts with their tags."""
+
+        tag = Tag.objects.create(name="Django")
+        post = Post.objects.create(
+            title="Hola mundo",
+            excerpt="Resumen del post",
+            content="Contenido detallado",
+            date=date(2024, 1, 1),
+            image="https://example.com/image.png",
+            thumb="https://example.com/thumb.png",
+            imageAlt="Texto alternativo",
+            author="Codex",
+        )
+        post.tags.add(tag)
+
+        response = self.client.get(self.list_url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        payload = response.data
+        self.assertEqual(payload["count"], 1)
+        result = payload["results"][0]
+        self.assertEqual(result["title"], post.title)
+        self.assertEqual(result["slug"], post.slug)
+        self.assertEqual(result["tags"], [tag.name])
+
+    def test_create_post_creates_missing_tags(self) -> None:
+        """Creating a post via the API should reuse and create tags by name."""
+
+        Tag.objects.create(name="Backend")
+
+        payload = {
+            "title": "Nuevo post",
+            "excerpt": "Extracto",
+            "content": "Contenido",
+            "date": "2024-02-01",
+            "image": "https://example.com/new.png",
+            "thumb": "https://example.com/new-thumb.png",
+            "imageAlt": "Otra imagen",
+            "author": "Equipo",
+            "tags": ["Backend", "APIs"],
+        }
+
+        response = self.client.post(self.list_url, payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        data = response.data
+        self.assertTrue(Tag.objects.filter(name="APIs").exists())
+
+        post = Post.objects.get(slug=data["slug"])
+        self.assertEqual(post.title, payload["title"])
+        self.assertSetEqual(
+            set(post.tags.values_list("name", flat=True)),
+            {"Backend", "APIs"},
+        )

--- a/instructions/backend/agents_backend.md
+++ b/instructions/backend/agents_backend.md
@@ -28,6 +28,15 @@ El backend del blog ya está operativo con Django REST Framework y Jazzmin.
 - `POST /api/posts/`: crea un post permitiendo pasar tags por nombre (se crean si no existen).
 - `GET /api/posts/<slug>/`: detalle por slug.
 
+## Pruebas automatizadas
+- Las pruebas viven en `blog/tests.py` y cubren el listado de posts y la creación de tags bajo demanda.
+- Ejecútalas con `python manage.py test` desde la carpeta `/backend`.
+- Antes de lanzarlas asegúrate de que la base de datos PostgreSQL está operativa. Si trabajas con Docker utiliza `docker compose up -d postgres` desde `/deploy` y luego `docker compose run --rm backend python manage.py test`.
+- Cuando modifiques modelos o migraciones, corre `python manage.py migrate` contra la base de datos en marcha para alinear el esquema previo a las pruebas.
+
+## Agente de pruebas backend
+Se creó un agente específico en `instructions/backend/agents_backend_tests.md` para profundizar en la estrategia de testing automatizado.
+
 ## Puesta en marcha local
 ```bash
 cd backend

--- a/instructions/backend/agents_backend_tests.md
+++ b/instructions/backend/agents_backend_tests.md
@@ -1,0 +1,31 @@
+# Agente Backend – Pruebas automatizadas (`/backend`)
+
+Este agente se encargará de mantener y ampliar la batería de pruebas del proyecto Django.
+
+## Alcance
+- Trabaja únicamente dentro de la carpeta `/backend`.
+- Prioriza las pruebas unitarias y de integración sobre los endpoints ya expuestos en `blog/views.py` y los serializers correspondientes.
+- Mantén los casos de prueba dentro de `blog/tests.py` salvo que la complejidad requiera dividirlos en un paquete `tests/` con archivos especializados.
+
+## Cómo ejecutar las pruebas
+1. Posiciónate en la carpeta `backend/`.
+2. Garantiza que existe una base de datos PostgreSQL disponible. Si estás desarrollando en local puedes reutilizar la orquestación definida en `/deploy/docker-compose.yml`:
+   ```bash
+   cd deploy
+   docker compose up -d postgres
+   docker compose run --rm backend python manage.py migrate  # solo si hay migraciones nuevas
+   docker compose run --rm backend python manage.py test
+   ```
+3. Si trabajas sin Docker, crea una base de datos PostgreSQL accesible con las credenciales de `.env` y ejecuta `python manage.py migrate && python manage.py test`.
+
+## Lineamientos para nuevas pruebas
+- Cubre tanto respuestas exitosas como validaciones de errores al interactuar con la API REST.
+- Siempre que añadas un endpoint nuevo, escribe al menos una prueba que verifique el caso feliz y otra que valide permisos o validaciones relevantes.
+- Usa `rest_framework.test.APITestCase` cuando necesites hacer peticiones HTTP completas y `django.test.TestCase` para probar lógica interna de modelos o utilidades.
+- Evita fixtures estáticos salvo que sean imprescindibles; prefiere crear los objetos necesarios dentro del test para mantenerlos aislados.
+- Documenta cualquier configuración adicional requerida para ejecutar las pruebas (por ejemplo, variables de entorno o datos semilla) directamente en este archivo.
+
+## Checklist previo a abrir un PR
+- [ ] Todos los tests pasan (`python manage.py test`).
+- [ ] Las migraciones nuevas se aplicaron sobre la base de datos apuntada por la configuración actual.
+- [ ] Se actualizó esta guía si cambió la forma de ejecutar o estructurar las pruebas.

--- a/instructions/deploy/agents_deploy.md
+++ b/instructions/deploy/agents_deploy.md
@@ -29,6 +29,11 @@ python manage.py loaddata blog/fixtures/seed_posts.json
 python manage.py createsuperuser  # opcional
 ```
 
+## Pruebas y migraciones en entornos de CI/CD
+- Antes de construir la imagen del backend ejecuta `python manage.py test` contra la base de datos PostgreSQL. Con Docker Compose puedes hacerlo con `docker compose run --rm backend python manage.py test` tras levantar `docker compose up -d postgres`.
+- Si el repositorio introduce migraciones nuevas, añade un paso que ejecute `python manage.py migrate` usando la misma base de datos preparada para las pruebas. Esto garantiza que el esquema queda sincronizado antes de desplegar.
+- Limpia los contenedores temporales de prueba (`docker compose rm -f backend`) para mantener los entornos efímeros y evitar datos residuales entre ejecuciones.
+
 Validar después del primer despliegue:
 - `/admin/` muestra el panel Jazzmin.
 - `GET https://backendblog.yampi.eu/api/posts/` responde con la lista paginada.


### PR DESCRIPTION
## Summary
- add API integration tests for listing and creating blog posts
- document the new backend testing agent and testing workflow expectations
- update deploy guidelines to run tests and apply migrations with a live PostgreSQL database

## Testing
- python manage.py test *(fails: requires PostgreSQL service `postgres`)*

------
https://chatgpt.com/codex/tasks/task_e_68f2b81e365883279d199e1c6550229f