### PR TITLE
Fix syntax error in blog serializers module

### DIFF
--- a/backend/blog/serializers.py
+++ b/backend/blog/serializers.py
@@ -136,4 +136,3 @@ class CommentSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError("El comentario debe tener al menos 5 caracteres.")
         return cleaned
 
-*** End of File


### PR DESCRIPTION
## Summary
- remove a stray "*** End of File" marker from the blog serializers module that caused a SyntaxError

## Testing
- python manage.py check *(fails: ModuleNotFoundError: No module named 'django_filters')*


------
https://chatgpt.com/codex/tasks/task_e_68f2e15f1f748327aeea0c258b3c0e2d