### PR TITLE
docs: documentar backend y agentes operativos

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,15 @@
+# Área de documentación
+
+Este directorio centraliza guías impresas y versionables para el monorepo CodexTest. Antes de editar, revisa las instrucciones de colaboración en `../instructions/agents.md`.
+
+## Índice
+- [Backend – Documentación](backend/README.md)
+- [Agentes del Backend](backend/agents.md)
+
+## Convenciones
+- Idioma principal: español técnico.
+- Formato: Markdown compatible con GitHub (tablas, bloques de código y referencias internas).
+- Para mantener consistencia con las instrucciones vivas en `../instructions`, evita duplicar contenido y enlaza a la fuente oficial siempre que sea posible.
+
+## Próximas expansiones
+- Documentación del frontend (`docs/frontend/`), infraestructura (`docs/deploy/`) y guías de UX se agregarán conforme avancen las tareas descritas en `../instructions`.

--- a/docs/backend/README.md
+++ b/docs/backend/README.md
@@ -1,0 +1,302 @@
+# Backend – Documentación
+
+> Consulta también la guía operativa para agentes en `../../instructions/backend/agents_backend.md` y las tareas activas en `../../instructions/backend.md` antes de realizar cambios relevantes.
+
+## Tabla de contenidos
+- [Resumen](#resumen)
+- [Arquitectura](#arquitectura)
+- [Requisitos](#requisitos)
+- [Configuración](#configuración)
+  - [Archivos estáticos](#archivos-estáticos)
+  - [Archivos multimedia](#archivos-multimedia)
+  - [CORS y CSRF](#cors-y-csrf)
+- [Base de datos](#base-de-datos)
+- [Comandos operativos](#comandos-operativos)
+- [API (referencia)](#api-referencia)
+  - [Documentación interactiva](#documentación-interactiva)
+  - [Posts](#posts)
+  - [Comentarios](#comentarios)
+  - [Paginación, filtros y ordenación](#paginación-filtros-y-ordenación)
+  - [Formato de errores](#formato-de-errores)
+- [Seeds](#seeds)
+- [Deploy](#deploy)
+- [CI/CD y pruebas](#cicd-y-pruebas)
+- [Troubleshooting](#troubleshooting)
+- [Versionado y cambios](#versionado-y-cambios)
+- [Glosario](#glosario)
+
+## Resumen
+El backend del proyecto CodexTest es un servicio web construido con **Django 5**, **Django REST Framework (DRF)**, **WhiteNoise** y **Gunicorn**. Provee la API pública que consume el frontend React (`/frontend`) y sirve como origen de datos para entradas de blog y sus comentarios. Se entrega como una aplicación WSGI empacada en contenedores que Dokploy orquesta junto con la capa de despliegue descrita en `../../deploy`.
+
+## Arquitectura
+```
+[Cliente HTTP]
+    │
+    ├─▶ /api/ (DRF + viewsets en `backend/blog/views.py`)
+    │      ├─ posts (CRUD parcial)
+    │      └─ comments (nested)
+    │
+    ├─▶ /api/docs|/api/redoc|/api/schema (drf-spectacular)
+    │
+    ├─▶ Seeds (`manage.py seed_*`, configuración en `backend/blog/seed_config.py`)
+    │
+    ├─▶ Archivos estáticos (`/static/` + WhiteNoise → `STATIC_ROOT=/backend/staticfiles`)
+    │
+    ├─▶ Archivos multimedia (`/media/` → volumen Dokploy opcional)
+    │
+    ├─▶ Entrypoint Docker (`deploy/backend/entrypoint.sh` → migrate → collectstatic → Gunicorn)
+    │
+    └─▶ Gunicorn (`backendblog.wsgi`) detrás de Dokploy / proxy HTTP
+```
+Rutas clave del repositorio:
+- `/backend/`: proyecto Django.
+  - `backendblog/`: configuración (`settings.py`, `urls.py`, `wsgi.py`).
+  - `blog/`: app principal con modelos (`models.py`), serializadores, vistas y seeds.
+- `deploy/backend/entrypoint.sh`: script de arranque usado en contenedores Dokploy.
+- `instructions/backend/agents_backend.md`: lineamientos de colaboración.
+
+## Requisitos
+- **Python 3.12**.
+- Dependencias listadas en `backend/requirements.txt` (Django 5, djangorestframework, django-filter, drf-spectacular, whitenoise, gunicorn, jazzmin, faker, psycopg[binary], etc.).
+
+Variables de entorno mínimas:
+
+| Variable | Descripción | Ejemplo |
+| --- | --- | --- |
+| `SECRET_KEY` | Clave criptográfica de Django. | `django-insecure-...` |
+| `DEBUG` | Activa modo debug (solo en desarrollo). | `true` |
+| `ALLOWED_HOSTS` | Lista CSV de hosts adicionales. | `backend.local,api.example.com` |
+| `CORS_ALLOWED_ORIGINS` | Orígenes permitidos (admite rutas específicas). | `https://cdryampi.github.io/CodexTest/` |
+| `CSRF_TRUSTED_ORIGINS` | Orígenes confiables para CSRF. | `https://backendblog.yampi.eu` |
+| `DATABASE_URL` | URL Postgres (se prioriza sobre variables `POSTGRES_*`). | `postgres://user:pass@db:5432/blog` |
+| `POSTGRES_*` | Parámetros individuales si no hay `DATABASE_URL`. | `POSTGRES_DB=blog` |
+| `GUNICORN_WORKERS` | Número de workers en producción. | `4` |
+| `GUNICORN_THREADS` | Hilos por worker. | `2` |
+| `GUNICORN_TIMEOUT` | Timeout en segundos. | `120` |
+| `ALLOW_SEED`, `ALLOW_SEED_RESET`, `SEED_ON_MIGRATE` | Flags para seeds (ver [Seeds](#seeds)). | `true/false` |
+| `DB_MAX_RETRIES`, `DB_RETRY_DELAY` | Retries de conexión en entrypoint. | `30`, `1` |
+
+## Configuración
+Configuración relevante extraída de `backend/backendblog/settings.py`:
+
+```python
+STATIC_URL = "/static/"
+STATIC_ROOT = BASE_DIR / "staticfiles"
+MEDIA_URL = "/media/"
+MEDIA_ROOT = BASE_DIR / "media"
+
+REST_FRAMEWORK = {
+    "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
+    "DEFAULT_AUTHENTICATION_CLASSES": [
+        "rest_framework.authentication.SessionAuthentication",
+    ],
+    "DEFAULT_PERMISSION_CLASSES": [
+        "rest_framework.permissions.AllowAny",
+    ],
+    "DEFAULT_PAGINATION_CLASS": "blog.pagination.DefaultPageNumberPagination",
+    "PAGE_SIZE": 10,
+    "DEFAULT_FILTER_BACKENDS": [
+        "django_filters.rest_framework.DjangoFilterBackend",
+        "rest_framework.filters.SearchFilter",
+        "rest_framework.filters.OrderingFilter",
+    ],
+}
+```
+
+### Archivos estáticos
+- `STATIC_URL=/static/` y `STATIC_ROOT=/backend/staticfiles`.
+- WhiteNoise (`whitenoise.storage.CompressedManifestStaticFilesStorage`) sirve los assets en contenedores sin necesidad de Nginx intermedio.
+- Ejecutar `python manage.py collectstatic --noinput` antes de levantar Gunicorn (automatizado en el entrypoint).
+
+### Archivos multimedia
+- `MEDIA_URL=/media/` y `MEDIA_ROOT=/backend/media`.
+- En desarrollo, sirven vía `DEBUG=True` y `django.conf.urls.static`. En producción, Dokploy debe montar un volumen persistente y exponerlo vía proxy inverso.
+
+### CORS y CSRF
+- `CORS_ALLOWED_ORIGINS` admite rutas con sufijos; el ajuste corta la ruta para la whitelist y añade una regex que respeta la ruta completa.
+- `CSRF_TRUSTED_ORIGINS` debe incluir los orígenes HTTPS utilizados por el frontend o el panel de administración.
+- Ajusta estas variables por entorno para evitar errores 403/CSRF.
+
+## Base de datos
+- Desarrollo rápido: usar SQLite ejecutando `DATABASE_URL=sqlite:///db.sqlite3` (no se versiona; útil en sesiones locales).
+- CI/Producción: Postgres vía `DATABASE_URL` o los parámetros `POSTGRES_*`.
+- El entrypoint (`deploy/backend/entrypoint.sh`) incluye un loop de espera configurable mediante `DB_MAX_RETRIES` y `DB_RETRY_DELAY` para garantizar disponibilidad antes de migrar.
+
+## Comandos operativos
+Ejecutar siempre desde `/backend` con el entorno activado.
+
+```bash
+# Migraciones
+env DJANGO_SETTINGS_MODULE=backendblog.settings python manage.py migrate --noinput
+
+# Recolección de estáticos
+env DJANGO_SETTINGS_MODULE=backendblog.settings python manage.py collectstatic --noinput
+
+# Superusuario para CI / demo
+env DJANGO_SETTINGS_MODULE=backendblog.settings DJANGO_SUPERUSER_USERNAME=ci-admin \
+    DJANGO_SUPERUSER_EMAIL=ci@example.com DJANGO_SUPERUSER_PASSWORD=ci-pass \
+    python manage.py createsuperuser --noinput
+
+# Seeds (ver sección dedicada)
+ALLOW_SEED=true python manage.py seed_all --fast
+```
+
+## API (referencia)
+Todas las rutas están bajo `/api/` según `backend/backendblog/urls.py`.
+
+### Documentación interactiva
+- Swagger UI: `GET /api/docs/`
+- Redoc: `GET /api/redoc/`
+- Esquema JSON: `GET /api/schema/`
+
+### Posts
+- **Listar** `GET /api/posts/?page=&page_size=&search=&ordering=&tags=`
+  - Parámetros:
+    - `page` / `page_size`: paginación numérica (máx. `page_size=50`).
+    - `search`: busca en `title`, `content` y nombres de tags.
+    - `ordering`: `created_at` (`date`), `-created_at`, `title`, `-title`.
+    - `tags`: múltiple usando `?tags=python&tags=django` (usa `tags__name`).
+  - Respuesta (extracto):
+
+```json
+{
+  "count": 120,
+  "next": "http://127.0.0.1:8000/api/posts/?page=2",
+  "previous": null,
+  "results": [
+    {
+      "id": 1,
+      "title": "Optimiza el renderizado en React",
+      "slug": "optimiza-el-renderizado-en-react",
+      "excerpt": "Resumen del artículo...",
+      "tags": ["react", "tutorial"],
+      "created_at": "2024-02-12",
+      "image": "https://picsum.photos/seed/react/1200/800"
+    }
+  ]
+}
+```
+
+- **Detalle** `GET /api/posts/{slug}/`
+- **Crear** `POST /api/posts/` (permiso actual `AllowAny`; pendiente endurecer). Cuerpo esperado:
+
+```json
+{
+  "title": "Novedades en Django 5",
+  "excerpt": "Resumen de las nuevas características...",
+  "content": "El contenido debe tener al menos 20 caracteres...",
+  "tags": ["django", "devops"],
+  "date": "2024-03-15",
+  "author": "Equipo CodexTest"
+}
+```
+
+Validaciones clave:
+- `title` ≥ 5 caracteres.
+- `content` ≥ 20 caracteres.
+- Los tags inexistentes se crean automáticamente.
+
+### Comentarios
+- **Listar** `GET /api/posts/{slug}/comments/`
+- **Crear** `POST /api/posts/{slug}/comments/`
+  - Payload mínimo:
+
+```json
+{
+  "author_name": "Ana",
+  "content": "Gran post, gracias por compartir!"
+}
+```
+
+- Comentarios se ordenan por `created_at` descendente.
+- Validaciones: `author_name` no vacío, `content` ≥ 5 caracteres.
+
+### Paginación, filtros y ordenación
+- Paginación: `PageNumberPagination` personalizada (`blog/pagination.py`) con `page`, `page_size` y límite de 50.
+- Filtros: `django-filter` permite `?tags=python` (se puede repetir el parámetro para múltiples tags).
+- Ordenación: `?ordering=created_at` o `?ordering=-title`.
+
+Consulta de ejemplo con `curl` y `jq`:
+```bash
+curl -sS http://127.0.0.1:8000/api/posts/?search=django\&ordering=-created_at | jq
+```
+
+Creación de comentario desde consola:
+```bash
+curl -sS -X POST http://127.0.0.1:8000/api/posts/mi-slug/comments/ \
+  -H 'Content-Type: application/json' \
+  -d '{"author_name":"Ana","content":"Gran post"}'
+```
+
+### Formato de errores
+DRF devuelve errores JSON estructurados. Ejemplos reales:
+
+```http
+HTTP/1.1 400 Bad Request
+Content-Type: application/json
+
+{"content": ["El comentario debe tener al menos 5 caracteres."]}
+```
+
+```http
+HTTP/1.1 404 Not Found
+Content-Type: application/json
+
+{"detail": "No encontrado."}
+```
+
+## Seeds
+Comandos disponibles (`backend/blog/management/commands`):
+- `seed_users` genera usuarios de prueba; evita duplicados por `username`/`email`.
+- `seed_posts` crea entradas con slugs únicos y asigna tags (creados si faltan).
+- `seed_comments` añade comentarios únicos usando firmas `(post_id, author, contenido)`.
+- `seed_all` orquesta las anteriores, permite `--fast` (12 usuarios, 40 posts, 1-3 comentarios) y `--reset` (requiere `ALLOW_SEED_RESET=true`).
+
+Características:
+- Idempotencia: cada comando verifica existencia antes de crear (slugs/títulos en posts, firmas en comentarios, `get_or_create` en usuarios y tags).
+- Flags de entorno:
+  - `ALLOW_SEED=true` o `DEBUG=true` habilitan seeds en entornos dinámicos.
+  - `ALLOW_SEED_RESET=true` permite el borrado previo de datos al usar `seed_all --reset`.
+  - `SEED_ON_MIGRATE=true` ejecuta seeds al aplicar migraciones (solo en entornos efímeros; evita producción).
+  - `STATIC_SEED_MODE=true` (por defecto) habilita modo determinista para fixtures reproducibles.
+
+## Deploy
+- Entrypoint (`deploy/backend/entrypoint.sh`):
+  1. Crea directorios `staticfiles` y `media`.
+  2. Espera a la base de datos (retry configurable).
+  3. Ejecuta `migrate --noinput` y `collectstatic --noinput`.
+  4. Arranca Gunicorn con variables `GUNICORN_*`.
+- En producción, Dokploy debe:
+  - Montar volúmenes persistentes para `/app/staticfiles` (opcional) y `/app/media`.
+  - Configurar healthchecks (`/admin/login/` o `/api/`) después de cada despliegue.
+  - Redeploy obligatorio tras cambiar variables de entorno.
+
+## CI/CD y pruebas
+- Job `agents_backend_test` (definido en `../../instructions/backend/agents_backend_tests.md`):
+  1. Provisiona Postgres efímero.
+  2. Ejecuta migraciones y `collectstatic`.
+  3. Opcionalmente corre `python manage.py seed_all --fast` si `ALLOW_SEED=true`.
+  4. Smoke tests: status 200 en `/admin/login/`, `/static/admin/css/base.css`, `/api/`.
+  5. Lanza `python manage.py test`.
+  6. Publica artefactos y limpia recursos.
+- Este job es gate obligatorio antes de merge o despliegue Dokploy.
+
+## Troubleshooting
+- **Panel /admin sin CSS**: falta `collectstatic` o configuración de WhiteNoise; reejecuta el comando y verifica permisos de `staticfiles`.
+- **400 Bad Request en producción**: revisa `ALLOWED_HOSTS` y `CSRF_TRUSTED_ORIGINS`.
+- **500 durante migrate**: la base de datos no está disponible; ajusta `DB_MAX_RETRIES` o añade espera previa.
+- **404 en /api/docs/**: confirma que `drf-spectacular` sigue en `INSTALLED_APPS` y que `backendblog/urls.py` incluye `SpectacularAPIView`.
+
+## Versionado y cambios
+- La API sigue **SemVer** simple (`MAJOR.MINOR.PATCH`) definida en `SPECTACULAR_SETTINGS["VERSION"]`.
+- Documenta breaking changes incrementando la versión mayor y registrándolas en este archivo.
+- Mantén changelog en `docs/backend/README.md` o crea una subsección nueva si se planifican releases.
+
+## Glosario
+- **DRF**: Django REST Framework, toolkit para construir APIs REST en Django.
+- **ViewSet**: Clase DRF que combina acciones (list, retrieve, create) en un único recurso.
+- **Router**: Registrador automático de rutas para viewsets.
+- **WhiteNoise**: Middleware que sirve archivos estáticos directamente desde Django.
+- **Seed**: Script que genera datos de ejemplo o iniciales.
+- **CI/CD**: Integración y entrega continuas.
+- **Dokploy**: Plataforma utilizada para desplegar los contenedores del backend.

--- a/docs/backend/agents.md
+++ b/docs/backend/agents.md
@@ -1,0 +1,99 @@
+# Agentes del Backend
+
+> Sigue las pautas globales en `../../instructions/agents.md` y las específicas del módulo en `../../instructions/backend/agents_backend.md` antes de coordinar o modificar flujos.
+
+## Tabla de contenidos
+- [Agente de pruebas (`agents_backend_test`)](#agente-de-pruebas-agents_backend_test)
+  - [Objetivo](#objetivo)
+  - [Flujo de trabajo](#flujo-de-trabajo)
+  - [Variables de entorno en CI](#variables-de-entorno-en-ci)
+  - [Criterios de aprobación y fallos comunes](#criterios-de-aprobación-y-fallos-comunes)
+- [Agente de deploy del backend](#agente-de-deploy-del-backend)
+  - [Responsabilidades](#responsabilidades)
+  - [Interacciones con Dokploy](#interacciones-con-dokploy)
+  - [Rollback y healthchecks](#rollback-y-healthchecks)
+- [Agente de seeds (opcional)](#agente-de-seeds-opcional)
+  - [Cuándo activarlo](#cuándo-activarlo)
+  - [Riesgos y controles](#riesgos-y-controles)
+- [Mantenimiento evolutivo](#mantenimiento-evolutivo)
+
+## Agente de pruebas (`agents_backend_test`)
+### Objetivo
+Garantizar que cada Pull Request o despliegue candidato preserve la integridad del backend Django descrito en `../README.md`.
+
+### Flujo de trabajo
+1. **Provisionamiento**: levanta una base de datos Postgres efímera (Docker service o contenedor sidecar).
+2. **Configuración de entorno**: exporta las variables mínimas (`SECRET_KEY`, `DEBUG=false`, `ALLOWED_HOSTS=127.0.0.1`, `DATABASE_URL=postgres://...`).
+3. **Migraciones**: ejecuta `python manage.py migrate --noinput`.
+4. **Estáticos**: `python manage.py collectstatic --noinput` para validar WhiteNoise.
+5. **Seeds opcionales**: si `ALLOW_SEED=true`, lanza `python manage.py seed_all --fast` para poblar datos básicos.
+6. **Smoke tests HTTP**: realiza peticiones `curl --fail` contra `/admin/login/`, `/static/admin/css/base.css` y `/api/` esperando código 200.
+7. **Pruebas unitarias**: `python manage.py test` (respetar `PYTHONPATH=/backend`).
+8. **Artefactos**: recopila logs, reportes HTML/JUnit y migra a almacenamiento temporal del pipeline.
+9. **Limpieza**: detiene contenedores/servicios y purga datos temporales.
+
+### Variables de entorno en CI
+Configurar secretos seguros en el sistema de CI (GitHub Actions, GitLab CI, Dokploy runners). Valores sugeridos:
+
+| Variable | Valor sugerido | Notas |
+| --- | --- | --- |
+| `SECRET_KEY` | `ci-secret-key` | Cambiar periódicamente. |
+| `DEBUG` | `false` | Debe ejecutarse en modo producción. |
+| `ALLOWED_HOSTS` | `127.0.0.1,localhost` | Añadir hostname del runner si aplica. |
+| `CORS_ALLOWED_ORIGINS` | `http://127.0.0.1:8000` | Necesario para pruebas de swagger. |
+| `CSRF_TRUSTED_ORIGINS` | `http://127.0.0.1:8000` | Evita falsos positivos en formularios. |
+| `DATABASE_URL` | `postgres://postgres:postgres@127.0.0.1:5432/postgres` | O usa variables `POSTGRES_*`. |
+| `ALLOW_SEED` | `true` | Habilita `seed_all --fast`. |
+| `ALLOW_SEED_RESET` | `false` | Evita borrado involuntario. |
+| `SEED_ON_MIGRATE` | `false` | Solo para entornos efímeros específicos. |
+| `STATIC_SEED_MODE` | `true` | Mantiene fixtures deterministas. |
+| `DB_MAX_RETRIES` | `30` | Sincronizado con entrypoint. |
+| `DB_RETRY_DELAY` | `1` | Segundos entre reintentos. |
+
+### Criterios de aprobación y fallos comunes
+- **Aprobado**: todas las etapas anteriores completan con código 0 y las pruebas retornan verde.
+- **Fallo típico – Migrations**: `django.db.utils.OperationalError` indica que Postgres no está listo; aumentar `DB_MAX_RETRIES` o añadir espera.
+- **Fallo típico – Staticfiles**: errores de `collectstatic` apuntan a rutas incorrectas o permisos; revisar configuración de `STATIC_ROOT`.
+- **Fallo típico – Tests**: revisar `backend/blog/tests.py`; actualizar fixtures o seeds si cambió el contrato.
+- **Fallo típico – Smoke tests**: códigos 403/400 suelen asociarse a `ALLOWED_HOSTS` o `CSRF_TRUSTED_ORIGINS`.
+
+## Agente de deploy del backend
+### Responsabilidades
+- Ejecutar el entrypoint `deploy/backend/entrypoint.sh` o replicar sus pasos (migraciones + collectstatic + arranque Gunicorn).
+- Validar que `STATIC_ROOT` y `MEDIA_ROOT` existan/monten volúmenes adecuados antes del arranque.
+- Administrar variables `GUNICORN_WORKERS`, `GUNICORN_THREADS`, `GUNICORN_TIMEOUT` basadas en recursos del cluster Dokploy.
+- Registrar la versión desplegada y actualizar `SPECTACULAR_SETTINGS["VERSION"]` cuando se publique una release.
+
+### Interacciones con Dokploy
+- El agente debe coordinarse con los manifiestos en `../../deploy`.
+- Cambios en variables de entorno requieren un **redeploy** completo para propagarse.
+- Recomienda activar healthchecks HTTP de Dokploy apuntando a `/api/` y `/admin/login/` con timeout < 10s.
+- Para migraciones largas, configurar ventanas de mantenimiento o ejecutar `manage.py migrate` manualmente antes del redeploy.
+
+### Rollback y healthchecks
+- Tras cada despliegue, monitorear:
+  - `/api/` responde 200 en < 500 ms.
+  - `/admin/login/` disponible con assets.
+  - Logs de Gunicorn sin trazas de error.
+- Si algún check falla:
+  1. Ejecutar rollback al artefacto previo (imagen Docker anterior).
+  2. Restaurar la base de datos desde snapshot/backup si las migraciones fueron destructivas.
+  3. Notificar a infraestructura y registrar incidente en el canal correspondiente.
+
+## Agente de seeds (opcional)
+### Cuándo activarlo
+- Entornos efímeros (preview apps, QA temporales) donde se requiera contenido demo inmediato.
+- Sesiones de testing manual que necesitan variedad de posts/comentarios.
+- No usar en producción estable salvo para campañas puntuales con control manual.
+
+### Riesgos y controles
+- Requiere `ALLOW_SEED=true`; validar que no se ejecute por accidente en producción.
+- `seed_all --reset` exige `ALLOW_SEED_RESET=true`; doble confirmación antes de habilitarlo.
+- El volumen de datos depende de `--fast` o de los valores por defecto (300 posts, 40 usuarios, 3-12 comentarios por post); ajustar parámetros para evitar sobrecargar la base.
+- Verifica logs tras cada ejecución y registra el resumen de `created/skipped` en la bitácora del entorno.
+
+## Mantenimiento evolutivo
+- Actualiza paginación, filtros y ordenación modificando `blog/pagination.py` y la configuración de `REST_FRAMEWORK`; documenta los cambios en `../README.md`.
+- Añade nuevas pruebas en `backend/blog/tests.py` y extiende el pipeline de `agents_backend_test` si se agregan endpoints.
+- Cuando se introduzcan endpoints adicionales, registra los contratos en la sección [API](../README.md#api-referencia) e incrementa la versión de `SPECTACULAR_SETTINGS` siguiendo SemVer.
+- Coordina modificaciones con los agentes de frontend y deploy a través de los documentos en `../../instructions/frontend` y `../../instructions/deploy`.


### PR DESCRIPTION
## Summary
- crear documentación detallada del backend Django y su API en `docs/backend/README.md`
- describir los flujos de los agentes de pruebas, despliegue y seeds en `docs/backend/agents.md`
- añadir un índice general para la carpeta de documentación

## Testing
- no tests were run (not needed)


------
https://chatgpt.com/codex/tasks/task_e_68f2e488b5788327b638b75ec5493fe8