### PR TITLE
Ensure backend allows CodexTest frontend via default CORS settings

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,4 +1,5 @@
 # Variables base para ejecutar backendblog
+# Nota: los orígenes del frontend oficial (GitHub Pages y localhost:5173) ya están permitidos por defecto.
 SECRET_KEY=change-me
 DEBUG=True
 SECURE_SSL_REDIRECT=False

--- a/backend/backendblog/settings.py
+++ b/backend/backendblog/settings.py
@@ -142,7 +142,19 @@ if SECURE_SSL_REDIRECT:
 
 CSRF_TRUSTED_ORIGINS = list(dict.fromkeys(_env_csv("CSRF_TRUSTED_ORIGINS")))
 
+# Orígenes permitidos por defecto para servir el frontend público de CodexTest
+_default_cors_origins = [
+    "https://cdryampi.github.io",
+    "https://cdryampi.github.io/CodexTest/",
+    "http://localhost:5173",
+    "http://127.0.0.1:5173",
+]
+
 _raw_cors_origins = _env_csv("CORS_ALLOWED_ORIGINS")
+if _raw_cors_origins:
+    _raw_cors_origins.extend(_default_cors_origins)
+else:
+    _raw_cors_origins = list(_default_cors_origins)
 CORS_ALLOWED_ORIGINS: list[str] = []
 CORS_ALLOWED_ORIGIN_REGEXES: list[str] = []
 for origin in _raw_cors_origins:


### PR DESCRIPTION
## Summary
- add default CORS origins covering the CodexTest GitHub Pages site and local development ports
- clarify in the sample environment file that these origins are already enabled by default

## Testing
- `python manage.py check` *(fails: missing django_filters in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f2f7149b488327adac986cee8305c0