### PR TITLE
Improve frontend data resilience and UX

### DIFF
--- a/frontend/src/components/NavBar.jsx
+++ b/frontend/src/components/NavBar.jsx
@@ -76,6 +76,8 @@ function NavBar() {
           onClick={toggleTheme}
           aria-label={themeLabel}
           title={themeLabel}
+          aria-pressed={isDark}
+          type="button"
           className="flex items-center gap-2 rounded-full border border-slate-200 bg-white/70 text-slate-600 transition duration-300 hover:-translate-y-0.5 hover:border-sky-500 hover:text-sky-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 dark:border-slate-700 dark:bg-slate-800/70 dark:text-slate-200 dark:hover:border-sky-400 dark:hover:text-sky-300 dark:focus-visible:ring-offset-slate-900"
         >
           {isDark ? <MoonIcon className="h-5 w-5" aria-hidden="true" /> : <SunIcon className="h-5 w-5" aria-hidden="true" />}

--- a/frontend/src/components/PostCard.jsx
+++ b/frontend/src/components/PostCard.jsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom';
+import { Link, generatePath } from 'react-router-dom';
 import { Badge } from 'flowbite-react';
 import { ArrowRightIcon, CalendarIcon, TagIcon } from '@heroicons/react/24/outline';
 
@@ -41,40 +41,62 @@ function PostCard({ post }) {
     return null;
   }
 
-  const { slug, title, excerpt, tags = [], created_at: createdAt, image } = post;
+  const { slug, title, excerpt, tags = [], created_at: createdAt } = post;
+  const thumbnail = post.thumbnail ?? post.image ?? null;
   const readingMinutes = estimateReadingMinutes(excerpt || title);
   const displayExcerpt = truncateText(excerpt);
+  const detailPath = slug ? generatePath('/post/:slug', { slug }) : '#';
 
   return (
-    <article className="group relative flex h-full flex-col overflow-hidden rounded-3xl border border-slate-200 bg-white/95 shadow-lg/20 ring-1 ring-transparent transition duration-300 hover:-translate-y-1 hover:border-sky-300 hover:ring-sky-100 focus-within:-translate-y-1 focus-within:border-sky-300 focus-within:ring-sky-100 dark:border-slate-800 dark:bg-slate-900/70 dark:hover:border-sky-500/60 dark:hover:ring-sky-500/20">
-      <span className="pointer-events-none absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-sky-500 via-fuchsia-500 to-sky-500 opacity-0 transition-opacity duration-300 group-hover:opacity-100" aria-hidden="true" />
-      {image ? (
-        <Link to={`/post/${slug}`} className="relative block h-56 overflow-hidden">
+    <article className="group relative flex h-full flex-col overflow-hidden rounded-3xl border border-slate-200 bg-white/95 shadow-lg/40 ring-1 ring-transparent transition duration-300 hover:-translate-y-1 hover:border-sky-300 hover:shadow-xl hover:ring-sky-100 focus-within:-translate-y-1 focus-within:border-sky-300 focus-within:ring-sky-100 dark:border-slate-800 dark:bg-slate-900/70 dark:hover:border-sky-500/60 dark:hover:shadow-sky-900/40 dark:hover:ring-sky-500/20">
+      <span
+        className="pointer-events-none absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-sky-500 via-fuchsia-500 to-sky-500 opacity-0 transition-opacity duration-300 group-hover:opacity-100"
+        aria-hidden="true"
+      />
+      {thumbnail ? (
+        <Link to={detailPath} className="relative block overflow-hidden">
           <img
-            src={image}
-            alt={`Imagen de portada para ${title}`}
-            className="h-full w-full object-cover transition duration-500 group-hover:scale-105"
+            src={thumbnail}
+            alt={title ? `Imagen ilustrativa para ${title}` : 'Imagen representativa de la publicación'}
+            className="h-56 w-full object-cover transition duration-500 group-hover:scale-105"
             loading="lazy"
           />
-          <span className="pointer-events-none absolute inset-0 bg-gradient-to-t from-slate-900/60 via-transparent to-transparent opacity-0 transition duration-300 group-hover:opacity-60" aria-hidden="true" />
+          <div
+            className="pointer-events-none absolute inset-0 bg-gradient-to-t from-slate-950/80 via-slate-950/10 to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-80"
+            aria-hidden="true"
+          />
+          <div
+            className="pointer-events-none absolute bottom-4 left-4 flex items-center gap-2 rounded-full bg-white/90 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-700 shadow-sm dark:bg-slate-900/80 dark:text-slate-200"
+            aria-hidden="true"
+          >
+            <CalendarIcon className="h-3.5 w-3.5" />
+            <span>{formatDate(createdAt)}</span>
+          </div>
         </Link>
       ) : (
-        <div className="h-2 bg-gradient-to-r from-sky-100 via-transparent to-sky-100 dark:from-slate-800 dark:to-slate-800" aria-hidden="true" />
+        <div
+          className="flex h-2 items-center justify-between bg-gradient-to-r from-sky-100 via-transparent to-sky-100 px-6 dark:from-slate-800 dark:via-slate-900 dark:to-slate-800"
+          aria-hidden="true"
+        >
+          <span className="h-1 w-10 rounded-full bg-sky-300/70 dark:bg-sky-500/50" />
+          <span className="h-1 w-16 rounded-full bg-fuchsia-300/70 dark:bg-fuchsia-500/40" />
+          <span className="h-1 w-8 rounded-full bg-sky-300/70 dark:bg-sky-500/50" />
+        </div>
       )}
       <div className="flex flex-1 flex-col gap-5 p-6">
-        <header className="space-y-3">
+        <header className="space-y-4">
           <div className="flex flex-wrap items-center justify-between gap-3 text-sm text-slate-500 dark:text-slate-400">
             <div className="flex items-center gap-2">
               <CalendarIcon className="h-4 w-4" aria-hidden="true" />
               <span>{formatDate(createdAt)}</span>
             </div>
-            <span className="inline-flex items-center gap-2 rounded-full bg-sky-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-sky-700 dark:bg-sky-900/60 dark:text-sky-200">
+            <span className="inline-flex items-center gap-2 rounded-full bg-sky-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-sky-700 shadow-sm dark:bg-sky-900/70 dark:text-sky-200">
               {readingMinutes} min de lectura
             </span>
           </div>
           <h2 className="text-2xl font-semibold text-slate-900 transition-colors duration-300 group-hover:text-sky-600 dark:text-white dark:group-hover:text-sky-300">
             <Link
-              to={`/post/${slug}`}
+              to={detailPath}
               className="relative inline-flex focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-900"
             >
               <span className="absolute inset-0" aria-hidden="true" />
@@ -91,7 +113,7 @@ function PostCard({ post }) {
               <Badge
                 key={tag}
                 color="info"
-                className="inline-flex items-center gap-1 border border-sky-200/60 bg-sky-100 text-sky-700 shadow-sm transition dark:border-sky-500/40 dark:bg-sky-900/40 dark:text-sky-200"
+                className="inline-flex items-center gap-1 border border-sky-200/60 bg-sky-100/80 text-sky-700 shadow-sm transition-colors duration-200 hover:border-sky-400 hover:bg-sky-50 hover:text-sky-600 dark:border-sky-500/40 dark:bg-sky-900/40 dark:text-sky-200 dark:hover:border-sky-400/70 dark:hover:bg-sky-900/60"
               >
                 <TagIcon className="h-4 w-4" aria-hidden="true" />
                 {tag}
@@ -100,9 +122,13 @@ function PostCard({ post }) {
           </div>
         ) : null}
         <div className="mt-auto flex items-center justify-between pt-2">
+          <div className="text-sm text-slate-500 dark:text-slate-400">
+            <span className="font-semibold text-slate-700 dark:text-slate-200">Explora este contenido</span>
+            <p>Profundiza en buenas prácticas listas para aplicar.</p>
+          </div>
           <Link
-            to={`/post/${slug}`}
-            className="inline-flex items-center gap-2 rounded-full border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-700 transition-colors duration-300 hover:border-sky-500 hover:text-sky-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 dark:border-slate-700 dark:text-slate-200 dark:hover:border-sky-400 dark:hover:text-sky-300 dark:focus-visible:ring-offset-slate-900"
+            to={detailPath}
+            className="inline-flex items-center gap-2 rounded-full border border-slate-300 bg-white/80 px-4 py-2 text-sm font-semibold text-slate-700 transition-colors duration-300 hover:-translate-y-0.5 hover:border-sky-500 hover:text-sky-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 dark:border-slate-700 dark:bg-slate-800/80 dark:text-slate-200 dark:hover:border-sky-400 dark:hover:text-sky-300 dark:focus-visible:ring-offset-slate-900"
           >
             Leer artículo
             <ArrowRightIcon className="h-4 w-4" aria-hidden="true" />

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -1,4 +1,9 @@
 import { apiGet, apiPost } from './apiClient';
+import postsSeed from '../data/posts.json';
+import commentsSeed from '../data/comments.json';
+
+const DEFAULT_PAGE_SIZE = 9;
+const COMMENT_STORAGE_PREFIX = 'blog:comments:';
 
 const sanitizeSearchTerm = (value = '') => value.toString().trim().toLowerCase();
 
@@ -12,6 +17,258 @@ const sanitizeTags = (tags = []) => {
   return Array.from(unique);
 };
 
+const safeStorage = {
+  get: (key) => {
+    if (typeof window === 'undefined') {
+      return null;
+    }
+
+    try {
+      return window.localStorage.getItem(key);
+    } catch (error) {
+      return null;
+    }
+  },
+  set: (key, value) => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    try {
+      window.localStorage.setItem(key, value);
+    } catch (error) {
+      // Ignorar errores de almacenamiento (modo incógnito, etc.).
+    }
+  }
+};
+
+const toISOString = (value) => {
+  if (!value) {
+    return null;
+  }
+
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value.toISOString();
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  return date.toISOString();
+};
+
+const ensureArray = (value) => (Array.isArray(value) ? value : []);
+
+const normalizePostRecord = (rawPost = {}) => {
+  const createdAt = toISOString(rawPost.created_at ?? rawPost.createdAt ?? rawPost.date);
+  const tags = ensureArray(rawPost.tags)
+    .map((tag) => tag.toString().trim())
+    .filter(Boolean);
+  const normalizedTags = tags.map((tag) => tag.toLowerCase());
+
+  return {
+    id: rawPost.id ?? rawPost.slug ?? globalThis.crypto?.randomUUID?.() ?? `${Date.now()}`,
+    slug: rawPost.slug,
+    title: rawPost.title ?? 'Publicación sin título',
+    excerpt: rawPost.excerpt ?? '',
+    content: rawPost.content ?? '',
+    created_at: createdAt,
+    tags,
+    author: rawPost.author ?? 'Equipo React Tailwind Blog',
+    image: rawPost.image ?? rawPost.cover ?? null,
+    thumbnail: rawPost.thumb ?? rawPost.thumbnail ?? rawPost.image ?? null,
+    _normalizedTags: normalizedTags,
+    _searchHaystack: [
+      rawPost.title ?? '',
+      rawPost.excerpt ?? '',
+      rawPost.content ?? '',
+      normalizedTags.join(' ')
+    ]
+      .join(' ')
+      .toLowerCase()
+  };
+};
+
+const normalizeCommentRecord = (rawComment = {}, slug = null, postId = null) => {
+  const createdAt = toISOString(rawComment.created_at ?? rawComment.createdAt ?? rawComment.date ?? Date.now());
+
+  return {
+    id: rawComment.id ?? `${slug ?? 'comment'}-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    author_name: rawComment.author_name ?? rawComment.author ?? 'Anónimo',
+    content: rawComment.content ?? '',
+    created_at: createdAt,
+    parent: rawComment.parent ?? rawComment.parent_id ?? rawComment.parentId ?? null,
+    postSlug: slug ?? rawComment.postSlug ?? null,
+    postId: postId ?? rawComment.postId ?? null
+  };
+};
+
+const seedPosts = ensureArray(postsSeed).map((post) => normalizePostRecord(post));
+const postsBySlug = new Map(seedPosts.filter((post) => post.slug).map((post) => [post.slug, post]));
+const postsById = new Map(seedPosts.map((post) => [post.id, post]));
+
+const seedComments = ensureArray(commentsSeed)
+  .map((comment) => {
+    const post = postsById.get(comment.postId);
+    const slug = post?.slug ?? null;
+    return normalizeCommentRecord(comment, slug, comment.postId);
+  })
+  .filter((comment) => !!comment.postSlug || !!comment.postId);
+
+const readStoredComments = (slug) => {
+  if (!slug) {
+    return [];
+  }
+
+  const raw = safeStorage.get(`${COMMENT_STORAGE_PREFIX}${slug}`);
+  if (!raw) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed
+      .map((comment) => normalizeCommentRecord(comment, slug))
+      .filter((comment) => Boolean(comment.content));
+  } catch (error) {
+    return [];
+  }
+};
+
+const persistStoredComments = (slug, comments) => {
+  if (!slug) {
+    return;
+  }
+
+  safeStorage.set(`${COMMENT_STORAGE_PREFIX}${slug}`, JSON.stringify(comments));
+};
+
+const sortByCreatedAt = (items = []) =>
+  [...items].sort((a, b) => {
+    const timeA = new Date(a.created_at ?? 0).getTime();
+    const timeB = new Date(b.created_at ?? 0).getTime();
+    return timeA - timeB;
+  });
+
+const filterPostsBySearch = (posts, term) => {
+  if (!term) {
+    return posts;
+  }
+  return posts.filter((post) => post._searchHaystack.includes(term));
+};
+
+const filterPostsByTags = (posts, tags) => {
+  if (!tags.length) {
+    return posts;
+  }
+
+  return posts.filter((post) => tags.every((tag) => post._normalizedTags.includes(tag)));
+};
+
+const orderPosts = (posts, ordering) => {
+  const normalizedOrdering = ordering || '-created_at';
+
+  const sorted = [...posts];
+
+  if (normalizedOrdering === 'title') {
+    sorted.sort((a, b) => a.title.localeCompare(b.title, 'es', { sensitivity: 'base' }));
+  } else {
+    const direction = normalizedOrdering.startsWith('-') ? -1 : 1;
+    sorted.sort((a, b) => {
+      const timeA = new Date(a.created_at ?? 0).getTime();
+      const timeB = new Date(b.created_at ?? 0).getTime();
+      return (timeA - timeB) * direction;
+    });
+  }
+
+  return sorted;
+};
+
+const paginatePosts = (posts, page, pageSize = DEFAULT_PAGE_SIZE) => {
+  const parsedPage = Number(page);
+  const parsedSize = Number(pageSize);
+  const currentPage = Number.isFinite(parsedPage) && parsedPage > 0 ? Math.floor(parsedPage) : 1;
+  const size = Number.isFinite(parsedSize) && parsedSize > 0 ? Math.floor(parsedSize) : DEFAULT_PAGE_SIZE;
+  const start = (currentPage - 1) * size;
+  const end = start + size;
+  const sliced = posts.slice(start, end);
+
+  return {
+    results: sliced.map(({ _searchHaystack, _normalizedTags, ...post }) => ({ ...post })),
+    count: posts.length,
+    next: end < posts.length ? currentPage + 1 : null,
+    previous: start > 0 ? currentPage - 1 : null
+  };
+};
+
+const listPostsFromSeed = ({ page = 1, search = '', ordering = '-created_at', tags = [] } = {}) => {
+  const term = sanitizeSearchTerm(search);
+  const normalizedTags = sanitizeTags(tags);
+
+  const filtered = filterPostsByTags(filterPostsBySearch(seedPosts, term), normalizedTags);
+  const ordered = orderPosts(filtered, ordering);
+  return paginatePosts(ordered, page);
+};
+
+const getPostFromSeed = (slug) => {
+  if (!slug) {
+    return null;
+  }
+
+  const post = postsBySlug.get(slug);
+  if (!post) {
+    return null;
+  }
+
+  const { _searchHaystack, _normalizedTags, ...rest } = post;
+  return { ...rest };
+};
+
+const listCommentsFromSeed = (slug) => {
+  if (!slug) {
+    return [];
+  }
+
+  const post = postsBySlug.get(slug);
+  if (!post) {
+    return [];
+  }
+
+  const baseComments = seedComments.filter((comment) => {
+    if (comment.postSlug) {
+      return comment.postSlug === slug;
+    }
+    if (comment.postId) {
+      return comment.postId === post.id;
+    }
+    return false;
+  });
+
+  const stored = readStoredComments(slug);
+
+  return sortByCreatedAt([...baseComments, ...stored]).map(({ postSlug, postId, ...comment }) => ({ ...comment }));
+};
+
+const storeLocalComment = (slug, comment) => {
+  if (!slug) {
+    return null;
+  }
+
+  const stored = readStoredComments(slug);
+  const normalized = normalizeCommentRecord(comment, slug);
+  const updated = [...stored, normalized].map(({ postSlug, postId, ...item }) => ({ ...item }));
+  persistStoredComments(slug, updated);
+  const { postSlug, postId, ...publicComment } = normalized;
+  return publicComment;
+};
+
+let remoteAvailable = true;
+
 export const listPosts = async ({
   page = 1,
   search = '',
@@ -19,20 +276,32 @@ export const listPosts = async ({
   tags = [],
   signal
 } = {}) => {
-  const params = {
-    page,
-    ordering,
-    search: sanitizeSearchTerm(search),
-    tags: sanitizeTags(tags).join(',')
-  };
+  if (remoteAvailable) {
+    try {
+      const params = {
+        page,
+        ordering,
+        search: sanitizeSearchTerm(search),
+        tags: sanitizeTags(tags).join(',')
+      };
 
-  const { data } = await apiGet('/api/posts/', { params, signal });
-  return {
-    results: Array.isArray(data?.results) ? data.results : [],
-    count: typeof data?.count === 'number' ? data.count : 0,
-    next: data?.next ?? null,
-    previous: data?.previous ?? null
-  };
+      const { data } = await apiGet('/api/posts/', { params, signal });
+      const results = Array.isArray(data?.results)
+        ? data.results.map((post) => ({ ...normalizePostRecord(post), _searchHaystack: undefined, _normalizedTags: undefined }))
+        : [];
+      const sanitizedResults = results.map(({ _searchHaystack, _normalizedTags, ...item }) => ({ ...item }));
+      return {
+        results: sanitizedResults,
+        count: typeof data?.count === 'number' ? data.count : sanitizedResults.length,
+        next: data?.next ?? null,
+        previous: data?.previous ?? null
+      };
+    } catch (error) {
+      remoteAvailable = false;
+    }
+  }
+
+  return listPostsFromSeed({ page, search, ordering, tags });
 };
 
 export const getPost = async (slug, { signal } = {}) => {
@@ -40,8 +309,25 @@ export const getPost = async (slug, { signal } = {}) => {
     throw new Error('Slug de publicación requerido');
   }
 
-  const { data } = await apiGet(`/api/posts/${slug}/`, { signal });
-  return data;
+  if (remoteAvailable) {
+    try {
+      const { data } = await apiGet(`/api/posts/${slug}/`, { signal });
+      const normalized = normalizePostRecord(data);
+      const { _searchHaystack, _normalizedTags, ...rest } = normalized;
+      return rest;
+    } catch (error) {
+      remoteAvailable = false;
+    }
+  }
+
+  const post = getPostFromSeed(slug);
+  if (!post) {
+    const notFoundError = new Error('Publicación no encontrada');
+    notFoundError.status = 404;
+    throw notFoundError;
+  }
+
+  return post;
 };
 
 export const listComments = async (slug, { signal } = {}) => {
@@ -49,21 +335,27 @@ export const listComments = async (slug, { signal } = {}) => {
     return [];
   }
 
-  try {
-    const { data } = await apiGet(`/api/posts/${slug}/comments/`, { signal });
-    if (Array.isArray(data)) {
-      return data;
+  if (remoteAvailable) {
+    try {
+      const { data } = await apiGet(`/api/posts/${slug}/comments/`, { signal });
+      const remoteComments = Array.isArray(data)
+        ? data
+        : Array.isArray(data?.results)
+          ? data.results
+          : [];
+
+      const normalized = remoteComments.map((comment) => normalizeCommentRecord(comment, slug));
+      const stored = readStoredComments(slug);
+      return sortByCreatedAt([...normalized, ...stored]).map(({ postSlug, postId, ...comment }) => ({ ...comment }));
+    } catch (error) {
+      if (error.status === 404) {
+        return [];
+      }
+      remoteAvailable = false;
     }
-    if (Array.isArray(data?.results)) {
-      return data.results;
-    }
-    return [];
-  } catch (error) {
-    if (error.status === 404) {
-      return [];
-    }
-    throw error;
   }
+
+  return listCommentsFromSeed(slug);
 };
 
 export const createComment = async (slug, payload, { signal } = {}) => {
@@ -86,11 +378,16 @@ export const createComment = async (slug, payload, { signal } = {}) => {
     throw new Error('El comentario no puede superar los 2000 caracteres.');
   }
 
-  const body = {
-    author_name: authorName,
-    content
-  };
+  if (remoteAvailable) {
+    try {
+      const body = { author_name: authorName, content };
+      const { data } = await apiPost(`/api/posts/${slug}/comments/`, { body, signal });
+      return data;
+    } catch (error) {
+      remoteAvailable = false;
+    }
+  }
 
-  const { data } = await apiPost(`/api/posts/${slug}/comments/`, { body, signal });
-  return data;
+  const stored = storeLocalComment(slug, { author_name: authorName, content });
+  return { ...stored, isLocalOnly: true };
 };

--- a/frontend/src/store/useUI.js
+++ b/frontend/src/store/useUI.js
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 
 const THEME_STORAGE_KEY = 'blog:ui:theme';
+const LEGACY_THEME_KEYS = ['blog-theme-preference'];
 const SEARCH_STORAGE_KEY = 'blog:ui:last-search';
 
 const safeStorage = {
@@ -49,6 +50,15 @@ const getInitialTheme = () => {
   if (stored === 'dark' || stored === 'light') {
     return stored;
   }
+
+  for (const legacyKey of LEGACY_THEME_KEYS) {
+    const legacyValue = safeStorage.get(legacyKey);
+    if (legacyValue === 'dark' || legacyValue === 'light') {
+      safeStorage.set(THEME_STORAGE_KEY, legacyValue);
+      return legacyValue;
+    }
+  }
+
   return resolveSystemTheme();
 };
 
@@ -142,6 +152,7 @@ export const useUIStore = create((set, get) => {
     setTheme: (nextTheme) => {
       const theme = nextTheme === 'dark' ? 'dark' : 'light';
       safeStorage.set(THEME_STORAGE_KEY, theme);
+      LEGACY_THEME_KEYS.forEach((key) => safeStorage.set(key, theme));
       applyTheme(theme);
       set({ theme });
     },


### PR DESCRIPTION
## Summary
- add a resilient data layer that falls back to bundled JSON content, including local comment persistence when the API is unavailable
- refresh the blog cards with enhanced visuals and reliable route generation for post links
- improve theme toggling by reusing legacy storage keys and exposing toggle state for assistive tech

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f303f79e1483279f0561f69086986c