### PR TITLE
Add category filter UI and update backend documentation

### DIFF
--- a/docs/backend/README.md
+++ b/docs/backend/README.md
@@ -150,12 +150,13 @@ Todas las rutas están bajo `/api/` según `backend/backendblog/urls.py`.
 - Esquema JSON: `GET /api/schema/`
 
 ### Posts
-- **Listar** `GET /api/posts/?page=&page_size=&search=&ordering=&tags=`
+- **Listar** `GET /api/posts/?page=&page_size=&search=&ordering=&tags=&category=`
   - Parámetros:
     - `page` / `page_size`: paginación numérica (máx. `page_size=50`).
     - `search`: busca en `title`, `content` y nombres de tags.
     - `ordering`: `created_at` (`date`), `-created_at`, `title`, `-title`.
     - `tags`: múltiple usando `?tags=python&tags=django` (usa `tags__name`).
+    - `category`: slug único que filtra por la categoría asociada al post.
   - Respuesta (extracto):
 
 ```json
@@ -170,6 +171,11 @@ Todas las rutas están bajo `/api/` según `backend/backendblog/urls.py`.
       "slug": "optimiza-el-renderizado-en-react",
       "excerpt": "Resumen del artículo...",
       "tags": ["react", "tutorial"],
+      "categories": ["frontend", "rendimiento"],
+      "categories_detail": [
+        { "slug": "frontend", "name": "Frontend", "description": "UI y diseño" },
+        { "slug": "rendimiento", "name": "Rendimiento", "description": "Perf tuning" }
+      ],
       "created_at": "2024-02-12",
       "image": "https://picsum.photos/seed/react/1200/800"
     }
@@ -186,6 +192,7 @@ Todas las rutas están bajo `/api/` según `backend/backendblog/urls.py`.
   "excerpt": "Resumen de las nuevas características...",
   "content": "El contenido debe tener al menos 20 caracteres...",
   "tags": ["django", "devops"],
+  "categories": ["backend", "productividad"],
   "date": "2024-03-15",
   "author": "Equipo CodexTest"
 }
@@ -195,6 +202,7 @@ Validaciones clave:
 - `title` ≥ 5 caracteres.
 - `content` ≥ 20 caracteres.
 - Los tags inexistentes se crean automáticamente.
+- Las categorías se envían por `slug`; si no existen se ignoran y se conserva la integridad de la relación.
 
 ### Comentarios
 - **Listar** `GET /api/posts/{slug}/comments/`
@@ -211,9 +219,17 @@ Validaciones clave:
 - Comentarios se ordenan por `created_at` descendente.
 - Validaciones: `author_name` no vacío, `content` ≥ 5 caracteres.
 
+### Categorías
+- **Listar** `GET /api/categories/?q=&is_active=&with_counts=`
+  - `q`: búsqueda textual en nombre o descripción (case-insensitive).
+  - `is_active`: admite `true/false`, `1/0` o `yes/no` para limitar por estado.
+  - `with_counts`: cuando es verdadero (`true`, `1`, `yes`) añade `post_count` con el total de posts asociados.
+- **Detalle** `GET /api/categories/{slug}/`
+- **Crear/Actualizar** `POST|PUT|PATCH /api/categories/` (requiere autenticación). Los slugs se generan automáticamente y se validan para evitar duplicados.
+
 ### Paginación, filtros y ordenación
 - Paginación: `PageNumberPagination` personalizada (`blog/pagination.py`) con `page`, `page_size` y límite de 50.
-- Filtros: `django-filter` permite `?tags=python` (se puede repetir el parámetro para múltiples tags).
+- Filtros: `django-filter` permite `?tags=python` (se puede repetir el parámetro para múltiples tags) y `?category=frontend` para restringir por slug de categoría.
 - Ordenación: `?ordering=created_at` o `?ordering=-title`.
 
 Consulta de ejemplo con `curl` y `jq`:

--- a/frontend/src/components/CategorySidebar.jsx
+++ b/frontend/src/components/CategorySidebar.jsx
@@ -1,7 +1,24 @@
-import { Sidebar, Badge, Button } from 'flowbite-react';
-import { Squares2X2Icon, ExclamationTriangleIcon } from '@heroicons/react/24/outline';
+import { Sidebar, Badge, Button, TextInput, ToggleSwitch } from 'flowbite-react';
+import {
+  Squares2X2Icon,
+  ExclamationTriangleIcon,
+  MagnifyingGlassIcon,
+  XMarkIcon
+} from '@heroicons/react/24/outline';
 
-function CategorySidebar({ categories = [], selected = null, error = null, onSelect, onRetry }) {
+function CategorySidebar({
+  categories = [],
+  selected = null,
+  error = null,
+  onSelect,
+  onRetry,
+  searchValue = '',
+  onSearchChange,
+  onSearchClear,
+  onlyActive = false,
+  onOnlyActiveChange,
+  onResetFilters
+}) {
   const handleSelect = (slug) => {
     if (slug === selected) {
       onSelect?.(null);
@@ -9,6 +26,22 @@ function CategorySidebar({ categories = [], selected = null, error = null, onSel
     }
     onSelect?.(slug);
   };
+
+  const handleSearchChange = (event) => {
+    onSearchChange?.(event.target.value);
+  };
+
+  const handleClearSearch = () => {
+    onSearchClear?.();
+  };
+
+  const handleToggleActive = (value) => {
+    onOnlyActiveChange?.(value);
+  };
+
+  const hasFiltersApplied = Boolean(searchValue?.trim()) || !onlyActive;
+  const selectionHidden =
+    Boolean(selected) && !categories.some((category) => category.slug === selected);
 
   if (error) {
     return (
@@ -27,20 +60,6 @@ function CategorySidebar({ categories = [], selected = null, error = null, onSel
     );
   }
 
-  if (!categories.length) {
-    return (
-      <Sidebar aria-label="Categorías del blog" className="rounded-3xl border border-slate-200 bg-white/80 shadow-sm dark:border-slate-800 dark:bg-slate-900/60">
-        <Sidebar.Items>
-          <Sidebar.ItemGroup>
-            <div className="space-y-2 p-4 text-sm text-slate-500 dark:text-slate-400">
-              <p>No hay categorías disponibles por ahora.</p>
-            </div>
-          </Sidebar.ItemGroup>
-        </Sidebar.Items>
-      </Sidebar>
-    );
-  }
-
   return (
     <Sidebar aria-label="Categorías del blog" className="rounded-3xl border border-slate-200 bg-white/80 shadow-sm dark:border-slate-800 dark:bg-slate-900/60">
       <Sidebar.Items>
@@ -50,35 +69,91 @@ function CategorySidebar({ categories = [], selected = null, error = null, onSel
               <Squares2X2Icon className="h-5 w-5 text-sky-500 dark:text-sky-300" aria-hidden="true" />
               <span>Categorías</span>
             </div>
-            <Button color="light" size="xs" onClick={() => onSelect?.(null)} disabled={!selected}>
-              Ver todas
-            </Button>
+            <div className="flex items-center gap-2">
+              {hasFiltersApplied ? (
+                <Button color="light" size="xs" onClick={() => onResetFilters?.()}>
+                  Restablecer
+                </Button>
+              ) : null}
+              <Button color="light" size="xs" onClick={() => onSelect?.(null)} disabled={!selected}>
+                Ver todas
+              </Button>
+            </div>
           </div>
+          <div className="space-y-3 px-4 pb-3">
+            <div className="relative">
+              <TextInput
+                type="search"
+                value={searchValue}
+                onChange={handleSearchChange}
+                icon={MagnifyingGlassIcon}
+                placeholder="Buscar categorías"
+                aria-label="Buscar categorías"
+                className="pr-10"
+              />
+              {searchValue ? (
+                <button
+                  type="button"
+                  onClick={handleClearSearch}
+                  className="absolute right-2 top-1/2 inline-flex h-8 w-8 -translate-y-1/2 items-center justify-center rounded-full text-slate-400 transition duration-200 hover:bg-slate-100 hover:text-slate-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 dark:text-slate-500 dark:hover:bg-slate-800 dark:hover:text-slate-300 dark:focus-visible:ring-offset-slate-900"
+                  aria-label="Limpiar búsqueda de categorías"
+                >
+                  <XMarkIcon className="h-5 w-5" aria-hidden="true" />
+                </button>
+              ) : null}
+            </div>
+            <ToggleSwitch
+              checked={onlyActive}
+              label={onlyActive ? 'Mostrando solo categorías activas' : 'Incluyendo categorías inactivas'}
+              onChange={handleToggleActive}
+              className="flex w-full items-center justify-between rounded-2xl bg-slate-100/60 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:bg-slate-800/50 dark:text-slate-400"
+            />
+          </div>
+          {selectionHidden ? (
+            <div className="px-4 pb-2 text-xs font-medium text-amber-600 dark:text-amber-300">
+              La categoría seleccionada no coincide con los filtros actuales.
+            </div>
+          ) : null}
           <div className="px-2 pb-3">
-            <ul className="space-y-1">
-              {categories.map((category) => {
-                const isActive = category.slug === selected;
-                const count = typeof category.post_count === 'number' ? category.post_count : 0;
-                return (
-                  <li key={category.slug}>
-                    <button
-                      type="button"
-                      onClick={() => handleSelect(category.slug)}
-                      className={`group flex w-full items-center justify-between rounded-2xl px-3 py-2 text-left text-sm transition duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-900 ${
-                        isActive
-                          ? 'bg-sky-100 text-sky-700 shadow-sm dark:bg-sky-900/50 dark:text-sky-200'
-                          : 'text-slate-600 hover:-translate-y-0.5 hover:bg-slate-100 hover:text-sky-600 dark:text-slate-300 dark:hover:bg-slate-800/80 dark:hover:text-sky-200'
-                      }`}
-                    >
-                      <span className="font-medium">{category.name}</span>
-                      <Badge color={isActive ? 'info' : 'gray'} size="sm">
-                        {count}
-                      </Badge>
-                    </button>
-                  </li>
-                );
-              })}
-            </ul>
+            {categories.length ? (
+              <ul className="space-y-1">
+                {categories.map((category) => {
+                  const isActive = category.slug === selected;
+                  const count = typeof category.post_count === 'number' ? category.post_count : 0;
+                  return (
+                    <li key={category.slug}>
+                      <button
+                        type="button"
+                        onClick={() => handleSelect(category.slug)}
+                        className={`group flex w-full items-center justify-between rounded-2xl px-3 py-2 text-left text-sm transition duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-900 ${
+                          isActive
+                            ? 'bg-sky-100 text-sky-700 shadow-sm dark:bg-sky-900/50 dark:text-sky-200'
+                            : 'text-slate-600 hover:-translate-y-0.5 hover:bg-slate-100 hover:text-sky-600 dark:text-slate-300 dark:hover:bg-slate-800/80 dark:hover:text-sky-200'
+                        }`}
+                      >
+                        <span className="font-medium">{category.name}</span>
+                        <Badge color={isActive ? 'info' : 'gray'} size="sm">
+                          {count}
+                        </Badge>
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            ) : (
+              <div className="space-y-3 rounded-2xl bg-white/80 p-4 text-sm text-slate-500 shadow-sm dark:bg-slate-900/60 dark:text-slate-300">
+                <p>
+                  {searchValue?.trim()
+                    ? 'No encontramos categorías que coincidan con tu búsqueda. Ajusta los filtros para ver más opciones.'
+                    : 'No hay categorías disponibles por ahora.'}
+                </p>
+                {searchValue?.trim() ? (
+                  <Button color="light" size="sm" onClick={handleClearSearch}>
+                    Limpiar búsqueda
+                  </Button>
+                ) : null}
+              </div>
+            )}
           </div>
         </Sidebar.ItemGroup>
       </Sidebar.Items>

--- a/frontend/src/store/useUI.js
+++ b/frontend/src/store/useUI.js
@@ -238,7 +238,7 @@ export const useUIStore = create((set, get) => {
     },
     resetFilters: () => {
       safeStorage.remove(SEARCH_STORAGE_KEY);
-      set({ search: '', ordering: '-created_at', selectedTags: [], selectedCategory: null, page: 1 });
+      set({ search: '', ordering: '-date', selectedTags: [], selectedCategory: null, page: 1 });
     }
   };
 });


### PR DESCRIPTION
## Summary
- enhance the blog homepage sidebar with category search, active toggles, and reset controls tied to the Django API
- persist filter reset behaviour for posts ordering and surface hidden selections
- document the new category capabilities and filters in the backend API reference

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f322af2224832796cfc5860c9d4793