### PR TITLE
Ensure posts tolerate empty category lists

### DIFF
--- a/frontend/src/components/PostCard.jsx
+++ b/frontend/src/components/PostCard.jsx
@@ -99,20 +99,31 @@ function PostCard({ post }) {
               {readingMinutes} min de lectura
             </span>
           </div>
-          {categories.length > 0 ? (
-            <div className="flex flex-wrap gap-2 text-xs text-slate-500 dark:text-slate-400">
-              {categories.map((category) => (
-                <Badge
-                  key={category.slug}
-                  color="purple"
-                  className="inline-flex items-center gap-1 border border-fuchsia-200/60 bg-fuchsia-100/80 text-fuchsia-700 shadow-sm transition-colors duration-200 hover:border-fuchsia-400 hover:bg-fuchsia-50 hover:text-fuchsia-600 dark:border-fuchsia-500/40 dark:bg-fuchsia-900/40 dark:text-fuchsia-200 dark:hover:border-fuchsia-400/70 dark:hover:bg-fuchsia-900/60"
-                >
-                  <Squares2X2Icon className="h-4 w-4" aria-hidden="true" />
-                  {category.name ?? category.slug}
-                </Badge>
-              ))}
-            </div>
-          ) : null}
+          <div className="flex flex-wrap gap-2 text-xs text-slate-500 dark:text-slate-400">
+            {categories.length > 0 ? (
+              categories.map((category, index) => {
+                const key = category.slug ?? category.name ?? `category-${index}`;
+                return (
+                  <Badge
+                    key={key}
+                    color="purple"
+                    className="inline-flex items-center gap-1 border border-fuchsia-200/60 bg-fuchsia-100/80 text-fuchsia-700 shadow-sm transition-colors duration-200 hover:border-fuchsia-400 hover:bg-fuchsia-50 hover:text-fuchsia-600 dark:border-fuchsia-500/40 dark:bg-fuchsia-900/40 dark:text-fuchsia-200 dark:hover:border-fuchsia-400/70 dark:hover:bg-fuchsia-900/60"
+                  >
+                    <Squares2X2Icon className="h-4 w-4" aria-hidden="true" />
+                    {category.name ?? category.slug ?? 'Categoría sin nombre'}
+                  </Badge>
+                );
+              })
+            ) : (
+              <Badge
+                color="gray"
+                className="inline-flex items-center gap-1 border border-slate-200/60 bg-slate-200/70 text-slate-600 dark:border-slate-700/60 dark:bg-slate-800/60 dark:text-slate-300"
+              >
+                <Squares2X2Icon className="h-4 w-4" aria-hidden="true" />
+                Sin categorías asignadas
+              </Badge>
+            )}
+          </div>
           <h2 className="text-2xl font-semibold text-slate-900 transition-colors duration-300 group-hover:text-sky-600 dark:text-white dark:group-hover:text-sky-300">
             <Link
               to={detailPath}

--- a/frontend/src/pages/PostDetail.jsx
+++ b/frontend/src/pages/PostDetail.jsx
@@ -203,16 +203,29 @@ function PostDetail() {
             {post.title}
           </h1>
           <div className="flex flex-wrap gap-2">
-            {categories.map((category) => (
+            {categories.length > 0 ? (
+              categories.map((category, index) => {
+                const key = category.slug ?? category.name ?? `category-${index}`;
+                return (
+                  <Badge
+                    key={key}
+                    color="purple"
+                    className="flex items-center gap-1 bg-fuchsia-100 text-fuchsia-700 dark:bg-fuchsia-900/60 dark:text-fuchsia-200"
+                  >
+                    <Squares2X2Icon className="h-4 w-4" aria-hidden="true" />
+                    {category.name ?? category.slug ?? 'Categoría sin nombre'}
+                  </Badge>
+                );
+              })
+            ) : (
               <Badge
-                key={category.slug}
-                color="purple"
-                className="flex items-center gap-1 bg-fuchsia-100 text-fuchsia-700 dark:bg-fuchsia-900/60 dark:text-fuchsia-200"
+                color="gray"
+                className="flex items-center gap-1 bg-slate-200/80 text-slate-600 dark:bg-slate-800/60 dark:text-slate-300"
               >
                 <Squares2X2Icon className="h-4 w-4" aria-hidden="true" />
-                {category.name ?? category.slug}
+                Esta publicación aún no tiene categorías asignadas
               </Badge>
-            ))}
+            )}
           </div>
           <div className="flex flex-wrap gap-2">
             {post.tags?.map((tag) => (


### PR DESCRIPTION
## Summary
- ensure post serializers always emit category arrays to avoid null payloads
- cover the empty-category scenario in post API tests
- show a friendly fallback in the post detail and cards when no categories are assigned

## Testing
- python manage.py test *(fails: could not translate host name "postgres" to address)*

------
https://chatgpt.com/codex/tasks/task_e_68f326673ebc83279c3b8635697c345b