### PR TITLE
Add backend slug coverage and frontend build CI

### DIFF
--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -1,0 +1,39 @@
+name: Frontend Build
+
+on:
+  push:
+    paths:
+      - 'frontend/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/frontend-build.yml'
+  pull_request:
+    paths:
+      - 'frontend/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/frontend-build.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Install and build frontend
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 18
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build frontend
+        run: npm run build

--- a/backend/blog/tests/test_categories.py
+++ b/backend/blog/tests/test_categories.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from django.contrib.auth import get_user_model
+from django.test import TestCase
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
@@ -116,3 +117,16 @@ class CategoryAPITestCase(APITestCase):
             set(post.categories.values_list("slug", flat=True)),
             {content_category.slug, testing_category.slug},
         )
+
+
+class CategoryModelTestCase(TestCase):
+    """Validate category slug generation without hitting the API."""
+
+    def test_slug_autoincrements_for_similar_names(self) -> None:
+        """Categories sharing a slug base should get incremental suffixes."""
+
+        first = Category.objects.create(name="Data Science")
+        second = Category.objects.create(name="Data Science!!")
+
+        self.assertEqual(first.slug, "data-science")
+        self.assertEqual(second.slug, "data-science-2")

--- a/backend/blog/tests/test_posts.py
+++ b/backend/blog/tests/test_posts.py
@@ -226,3 +226,33 @@ class CommentAPITestCase(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertTrue(Comment.objects.filter(post=self.post, author_name="Laura").exists())
+
+    def test_duplicate_title_creates_incremental_slug(self) -> None:
+        """Posts that share the same title must generate unique slugs."""
+
+        first_post = Post.objects.create(
+            title="Título duplicado",
+            excerpt="Resumen",
+            content="Contenido " * 2,
+            date=date.today(),
+            image="https://example.com/post.png",
+            thumb="https://example.com/post-thumb.png",
+            imageAlt="Alt",
+            author="Codex",
+        )
+        first_post.tags.add(Tag.objects.create(name="Duplicado base"))
+
+        duplicate_post = Post.objects.create(
+            title="Título duplicado",
+            excerpt="Resumen",
+            content="Contenido " * 2,
+            date=date.today(),
+            image="https://example.com/post-2.png",
+            thumb="https://example.com/post-thumb-2.png",
+            imageAlt="Alt",
+            author="Codex",
+        )
+        duplicate_post.tags.add(Tag.objects.create(name="Duplicado extra"))
+
+        self.assertEqual(first_post.slug, "titulo-duplicado")
+        self.assertEqual(duplicate_post.slug, "titulo-duplicado-2")


### PR DESCRIPTION
## Summary
- add regression tests ensuring slug generation for posts and categories
- create a dedicated GitHub Actions workflow that builds the frontend on pushes and pull requests

## Testing
- python backend/manage.py test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f47d625f94832787c865af9231bb3e