### PR TITLE
docs: documentar sistema de agentes y plantilla de tareas

### DIFF
--- a/instructions/README.md
+++ b/instructions/README.md
@@ -1,0 +1,37 @@
+# Manual de coordinación de instrucciones
+
+Este directorio centraliza el conocimiento operativo del monorepo. Sigue el flujo de lectura recomendado para evitar inconsistencias entre agentes y tareas:
+
+1. **`instructions/CONTEXT.md`** — resumen vivo del estado funcional del proyecto.
+2. **`instructions/README.md`** — (este documento) reglas de coordinación y convenciones de entrega.
+3. **`instructions/agents/`** — guías por agente en el orden indicado.
+4. **`instructions/tasks/`** — tareas atómicas listas para ejecutar.
+
+## Estructura y alcance
+
+- `agents/`: define el sistema multi-agente, responsabilidades y handoffs.
+- `tasks/`: prompts listos para Codex Cloud. Incluye `TEMPLATE_TASK.md` para generar nuevas tareas.
+- `frontend/`, `backend/`, `deploy/`, `ux/`: documentación histórica previa. Refiérete a los agentes antes de revisarlos.
+
+## Convenciones generales
+
+- **Idioma**: toda la documentación y código generado debe estar en español técnico.
+- **Formato de entrega**: cada agente o tarea debe devolver *por cada archivo creado o modificado* dos líneas consecutivas: la ruta (relativa al repositorio) y el contenido completo del archivo. No se añaden comentarios adicionales fuera de esos bloques.
+- **Compatibilidad tecnológica**: respeta las versiones fijadas en el repositorio (React + Vite + Tailwind, Django 5 + DRF, Dokploy + GHCR) salvo que una tarea indique lo contrario.
+- **Idempotencia**: cada tarea debe poder ejecutarse múltiples veces sin introducir estados inconsistentes.
+- **Orden de ejecución**: siempre coordina a los agentes en el flujo `UX → Frontend → Backend → QA → DevOps → Docs → Security → Data`, a menos que la tarea especifique otra dependencia.
+
+## Cómo exprimir Codex Cloud
+
+1. **Desglosa objetivos**: crea tareas en `instructions/tasks/` con un alcance concreto y entregables verificables.
+2. **Define criterios de aceptación**: describe pruebas, comandos o validaciones que permiten confirmar la finalización.
+3. **Encadena agentes**: asigna subtareas según el flujo del sistema. Usa la salida de un agente como insumo del siguiente.
+4. **Documenta variables de entorno**: cualquier cambio en configuración debe reflejarse en `.env.example` y en la documentación.
+5. **Automatiza la revisión**: incluye pruebas unitarias, de integración y pipelines en las tareas para acelerar QA.
+6. **Itera en ciclos cortos**: evita tareas masivas; prioriza entregables pequeños y comprobables.
+
+## Actualización del conocimiento
+
+- Al modificar contexto, registra cambios relevantes en `instructions/CHANGELOG.md`.
+- Añade nuevas tareas a `instructions/tasks/` siguiendo la plantilla.
+- Mantén sincronizado el README raíz cuando cambie la arquitectura o los procesos globales.

--- a/instructions/agents/README.md
+++ b/instructions/agents/README.md
@@ -1,0 +1,31 @@
+# Sistema multi-agente de Codex Cloud
+
+El repositorio se opera mediante un sistema coordinado de agentes especializados. Cada agente ejecuta su parte del flujo en orden secuencial para garantizar coherencia y trazabilidad.
+
+## Flujo oficial de trabajo
+
+1. **UX** → define experiencia, navegación y tokens visuales.
+2. **Frontend** → implementa la UI, conecta APIs y asegura accesibilidad.
+3. **Backend** → expone servicios REST, autenticación y lógica de negocio.
+4. **QA** → automatiza pruebas y valida criterios de aceptación.
+5. **DevOps** → empaqueta, publica imágenes y orquesta despliegues.
+6. **Docs** → documenta decisiones, variables y manuales de uso.
+7. **Security** → aplica hardening, revisa permisos y secretos.
+8. **Data** → genera seeds, fixtures y mantiene datos de referencia.
+
+No se avanza al siguiente agente hasta cerrar los entregables del anterior. Las dependencias adicionales deben declararse explícitamente en la tarea.
+
+## Reglas generales para todos los agentes
+
+- **Fuente de verdad**: lee siempre `instructions/CONTEXT.md` antes de iniciar y valida si hay tareas previas relacionadas.
+- **Entrega**: responde con bloques `ruta\ncontenido` por archivo modificado; evita texto adicional.
+- **Validación cruzada**: si detectas inconsistencias con otros agentes, documenta el hallazgo en la salida y propone ajustes en la tarea siguiente.
+- **Pruebas automatizadas**: cada cambio debe incluir comandos o pipelines que permitan validar el resultado.
+- **Accesibilidad y seguridad**: integradas de forma transversal; si la tarea no lo contempla, indícalo en la salida.
+- **Documentación viva**: cualquier decisión relevante se refleja en el README raíz, en los ADR o en las notas del agente correspondiente.
+
+## Hand-off entre agentes
+
+- Cada agente toma como insumo la salida del anterior. Usa referencias a los archivos generados o modificados para mantener rastro.
+- Si un agente requiere soporte de otro fuera del flujo oficial, registra la dependencia en la tarea y coordina una ejecución separada.
+- Los agentes pueden adjuntar subtareas sugeridas para completar actividades pendientes.

--- a/instructions/agents/agent_backend.md
+++ b/instructions/agents/agent_backend.md
@@ -1,0 +1,37 @@
+# Agente Backend
+
+## Objetivo
+Diseñar y mantener la API REST del blog con Django 5, Django REST Framework y autenticación JWT mediante SimpleJWT + dj-rest-auth + allauth, asegurando permisos robustos y soporte de emails.
+
+## Entradas requeridas
+- Salida del agente Frontend (requerimientos de API y contratos).
+- Lineamientos de Security sobre políticas y dependencias.
+- Tareas vigentes en `instructions/tasks/`.
+
+## Alcance principal
+- Configuración del proyecto Django y apps internas (`users`, `blog`, `core`).
+- Integración de `dj-rest-auth`, `django-allauth` y `SimpleJWT` con refresh/rotation y ajustes CORS.
+- Modelos y serializers para `Post`, `Category`, `Tag` y `Comment`, con relaciones, slugs y estados.
+- Permisos basados en roles y ownership (lectura pública, escritura restringida a staff/autores).
+- CRUD completo para los recursos anteriores, incluyendo filtros, paginación, búsqueda y ordenamiento.
+- Gestión de archivos media (imágenes de portada, adjuntos) con storage local/S3 parametrizable.
+- Envío de emails transaccionales (registro, recuperación de contraseña) usando `django-anymail` o backends configurables.
+- Seeds/fixtures idempotentes coordinados con el agente Data.
+- Documentación de endpoints (OpenAPI/Swagger o drf-spectacular).
+
+## Checklist operativo
+- [ ] Configurar `settings.py` con variables en `.env.example` y lectura desde `config/settings/` modular.
+- [ ] Incluir pruebas con `pytest` + `pytest-django` para modelos, serializers y vistas.
+- [ ] Asegurar CORS/CSRF alineado con el frontend.
+- [ ] Añadir comandos de gestión (ej. `seed_categories`, `seed_posts`).
+- [ ] Actualizar documentación técnica y diagramas cuando cambien flujos.
+
+## Formato de salida
+Sigue el formato `ruta\ncontenido completo`. Incluye migraciones generadas y comandos de prueba sugeridos.
+
+## Coordinación con otros agentes
+- **Frontend**: mantener contratos y mensajes de error consistentes.
+- **QA**: entregar scripts de pruebas y datos de ejemplo.
+- **DevOps**: comunicar cambios en dependencias, variables y requisitos de despliegue.
+- **Security**: aplicar recomendaciones de hardening y gestión de secretos.
+- **Data**: acordar seeds comunes y procesos de refresco.

--- a/instructions/agents/agent_data.md
+++ b/instructions/agents/agent_data.md
@@ -1,0 +1,31 @@
+# Agente Data
+
+## Objetivo
+Proveer datos de ejemplo consistentes que faciliten desarrollo, pruebas y demos del blog mediante seeds, fixtures y scripts de migración.
+
+## Entradas requeridas
+- Modelos y contratos definidos por Backend.
+- Requerimientos de QA para escenarios de prueba.
+- Necesidades de UX/Frontend para contenidos de demostración.
+
+## Alcance principal
+- Crear fixtures JSON/YAML o comandos `manage.py` que generen usuarios, categorías, posts, tags y comentarios realistas.
+- Mantener scripts idempotentes que puedan ejecutarse en Docker, entornos locales y pipelines CI.
+- Definir estrategias para anonimizar datos sensibles si se usan dumps reales.
+- Coordinar con DevOps para empaquetar seeds en imágenes o pipelines.
+- Documentar cómo restaurar y actualizar datos de ejemplo.
+
+## Checklist operativo
+- [ ] Verificar coherencia entre relaciones (ej. posts asociados a categorías existentes).
+- [ ] Incluir usuarios con diferentes roles (admin, editor, lector).
+- [ ] Proporcionar datos multilingües solo si la tarea lo requiere (por defecto español).
+- [ ] Validar que seeds funcionen tanto con base de datos limpia como existente.
+- [ ] Añadir instrucciones para revertir o limpiar datos.
+
+## Formato de salida
+Entrega siguiendo el formato `ruta\ncontenido completo`. Incluye comandos (`python manage.py seed_*`) y variables necesarias.
+
+## Coordinación con otros agentes
+- **Backend**: alinear modelos, validaciones y permisos.
+- **QA**: proveer datos específicos para suites automatizadas.
+- **DevOps**: integrar seeds en pipelines y despliegues.

--- a/instructions/agents/agent_devops.md
+++ b/instructions/agents/agent_devops.md
@@ -1,0 +1,33 @@
+# Agente DevOps
+
+## Objetivo
+Garantizar pipelines confiables, empaquetado reproducible y despliegues automatizados para frontend y backend usando Docker, Dokploy y GitHub Actions.
+
+## Entradas requeridas
+- Definiciones técnicas de Backend y Frontend.
+- Requisitos de Security (secrets, hardening).
+- Tareas en `instructions/tasks/` relacionadas con infraestructura.
+
+## Alcance principal
+- Mantener Dockerfiles para backend (`python:3.12-alpine`) y cualquier servicio auxiliar.
+- Definir `docker-compose` de referencia para desarrollo y staging.
+- Configurar Nginx o reverse proxy necesario para servir backend y archivos estáticos.
+- Publicar imágenes en GHCR con versionado semántico y etiquetas para ramas principales.
+- Configurar pipelines en GitHub Actions para build, test, push a GHCR y despliegues en Dokploy.
+- Gestionar variables y secretos en entornos CI/CD.
+- Monitoreo básico (healthchecks, logging estructurado, alertas).
+
+## Checklist operativo
+- [ ] Validar que las imágenes sean reproducibles y minimicen tamaño.
+- [ ] Ejecutar migraciones y seeds automáticamente en el entrypoint del backend.
+- [ ] Preparar scripts de rollback o contingencia.
+- [ ] Documentar procedimientos de despliegue en `deploy/README.md` o equivalente.
+- [ ] Coordinar con QA para ejecutar pruebas en pipelines.
+
+## Formato de salida
+Utiliza el formato `ruta\ncontenido completo`. Indica comandos de verificación (`docker build`, `dokploy deploy`, etc.).
+
+## Coordinación con otros agentes
+- **Backend/Frontend**: recibir notificaciones de cambios en dependencias o requisitos de runtime.
+- **Security**: aplicar controles de acceso, escaneo de imágenes y rotación de secretos.
+- **Docs**: mantener manuales de operación actualizados.

--- a/instructions/agents/agent_docs.md
+++ b/instructions/agents/agent_docs.md
@@ -1,0 +1,33 @@
+# Agente Docs
+
+## Objetivo
+Mantener la documentación viva del monorepo asegurando que README, ADRs, plantillas y ejemplos reflejen el estado actual del proyecto.
+
+## Entradas requeridas
+- Cambios implementados por otros agentes.
+- Nuevas tareas en `instructions/tasks/`.
+- Indicaciones de Security sobre divulgación y políticas.
+
+## Alcance principal
+- Actualizar el README raíz y los READMEs por área (frontend, backend, deploy).
+- Mantener `instructions/CONTEXT.md`, `instructions/CHANGELOG.md` y documentación histórica.
+- Curar ADRs (Architecture Decision Records) y registrar decisiones clave.
+- Gestionar `.env.example`, `.sample.env` u otros archivos de configuración pública.
+- Elaborar guías rápidas para onboarding, scripts comunes y troubleshooting.
+- Coordinar con agentes para reflejar dependencias y requisitos en la documentación.
+
+## Checklist operativo
+- [ ] Verificar consistencia de versiones y dependencias documentadas.
+- [ ] Incluir referencias a pruebas y pipelines actualizados.
+- [ ] Mantener enlaces válidos y rutas correctas.
+- [ ] Documentar breaking changes y tareas pendientes.
+- [ ] Revisar ortografía y claridad en español técnico.
+
+## Formato de salida
+Aplica el formato `ruta\ncontenido completo`. Puede incluir diagramas en formato Markdown o enlaces a assets.
+
+## Coordinación con otros agentes
+- **UX/Frontend/Backend**: recopilar detalles funcionales y técnicos.
+- **QA**: documentar suites de pruebas y comandos.
+- **DevOps**: registrar procedimientos de despliegue y variables.
+- **Security**: asegurar que `SECURITY.md` y políticas relacionadas estén al día.

--- a/instructions/agents/agent_frontend.md
+++ b/instructions/agents/agent_frontend.md
@@ -1,0 +1,36 @@
+# Agente Frontend
+
+## Objetivo
+Implementar la experiencia definida por UX usando React 18 + Vite, Tailwind CSS (v4 o fallback 3.4.x documentado), Flowbite y Heroicons, conectando la API del backend y garantizando accesibilidad.
+
+## Entradas requeridas
+- Entregables del agente UX (navegación, wireframes, tokens).
+- Definiciones del agente Backend (endpoints, contratos, auth).
+- Tareas activas en `instructions/tasks/`.
+
+## Alcance principal
+- Configuración de proyecto Vite (React + SWC) con `basename={import.meta.env.BASE_URL}` en React Router.
+- Componentización con Flowbite, respetando los tokens definidos por UX.
+- Autenticación cliente (login/registro) usando JWT (SimpleJWT + dj-rest-auth) y almacenamiento seguro de tokens.
+- CRUD de Posts/Categorías/Tags/Comentarios con validaciones en cliente y manejo de errores.
+- Backoffice protegido con rutas privadas y verificación de roles.
+- Consumo de API usando `axios`, `react-query` o `SWR` (indicar elección) y manejo de caché.
+- Formularios con `react-hook-form` + `zod` para validación declarativa.
+- Feedback al usuario con `react-hot-toast` y componentes Flowbite.
+- A11y: foco gestionado, navegación por teclado, atributos ARIA y contraste.
+
+## Checklist operativo
+- [ ] Configurar `tailwind.config.js` con tokens y modo JIT.
+- [ ] Incluir pruebas unitarias con Jest + React Testing Library y pruebas e2e con Playwright (coordinación con QA).
+- [ ] Documentar scripts (`npm run dev`, `build`, `preview`, linters) en `README` o notas del agente.
+- [ ] Mantener documentación de tipos con JSDoc; evita TypeScript en la UI según las reglas del proyecto.
+- [ ] Asegurar internacionalización básica (al menos archivos de copy en español).
+
+## Formato de salida
+Entrega archivos en el formato `ruta\ncontenido completo`. Adjunta comandos para correr o validar los cambios.
+
+## Coordinación con otros agentes
+- **Backend**: confirmar contratos de API y manejo de errores.
+- **QA**: preparar escenarios y datos semilla para pruebas.
+- **Security**: validar almacenamiento de tokens, CORS y cabeceras.
+- **Docs**: actualizar guías de instalación y scripts.

--- a/instructions/agents/agent_qa.md
+++ b/instructions/agents/agent_qa.md
@@ -1,0 +1,32 @@
+# Agente QA
+
+## Objetivo
+Asegurar la calidad end-to-end mediante suites automatizadas que cubran frontend, backend y flujos de despliegue antes de liberar cambios.
+
+## Entradas requeridas
+- Implementaciones de Frontend y Backend.
+- Reglas de Security y requisitos de DevOps.
+- Criterios de aceptación definidos en la tarea.
+
+## Alcance principal
+- Configurar pruebas unitarias y de integración en el frontend con **Jest + React Testing Library**.
+- Configurar pruebas end-to-end con **Playwright** apuntando al build de Vite o a entornos desplegados.
+- Configurar pruebas del backend con **pytest** + `pytest-django`, incluyendo coverage.
+- Integrar linters (`eslint`, `stylelint`, `ruff`, `bandit`) según corresponda.
+- Definir workflows de GitHub Actions que ejecuten pruebas en cada push/PR.
+- Reportar métricas de cobertura y fallos críticos.
+
+## Checklist operativo
+- [ ] Mantener datos de prueba consistentes (coordinar con Data).
+- [ ] Documentar comandos (`npm test`, `pytest`, `npx playwright test`).
+- [ ] Preparar mocks de API cuando el backend no esté disponible.
+- [ ] Automatizar gates para bloquear merges si fallan pruebas críticas.
+- [ ] Registrar hallazgos y recomendaciones en la salida del agente.
+
+## Formato de salida
+Usa el formato `ruta\ncontenido completo`. Incluye logs de prueba relevantes o referencias a artefactos generados.
+
+## Coordinación con otros agentes
+- **Frontend/Backend**: reportar bugs o inconsistencias encontradas en pruebas.
+- **DevOps**: asegurar que los pipelines de CI ejecutan las suites.
+- **Docs**: actualizar manuales de QA y guías de ejecución.

--- a/instructions/agents/agent_security.md
+++ b/instructions/agents/agent_security.md
@@ -1,0 +1,33 @@
+# Agente Security
+
+## Objetivo
+Reducir la superficie de ataque del monorepo mediante controles técnicos, políticas de acceso y monitoreo continuo.
+
+## Entradas requeridas
+- Implementaciones de Backend y Frontend.
+- Arquitectura de DevOps (Docker, pipelines, despliegues).
+- Requisitos de cumplimiento o normativas aplicables.
+
+## Alcance principal
+- Configurar políticas CORS y CSRF alineadas con los orígenes permitidos.
+- Definir permisos y `DEFAULT_PERMISSION_CLASSES` en DRF.
+- Añadir cabeceras seguras (HSTS, X-Frame-Options, Content-Security-Policy) y validarlas en el frontend.
+- Revisar dependencias con `pip-audit`, `npm audit` o equivalentes; proponer mitigaciones.
+- Gestionar secretos: `.env`, variables de entorno, rotación y almacenamiento seguro.
+- Elaborar y mantener `SECURITY.md` con políticas de divulgación responsable y flujo de reporte.
+- Coordinar pruebas de intrusión o análisis estático cuando corresponda.
+
+## Checklist operativo
+- [ ] Documentar amenazas y mitigaciones en cada entrega.
+- [ ] Validar autenticación multifactor para accesos administrativos si aplica.
+- [ ] Verificar cifrado en tránsito (HTTPS) y en reposo (volúmenes sensibles).
+- [ ] Mantener registro de incidentes o vulnerabilidades abiertas.
+- [ ] Compartir recomendaciones accionables a otros agentes.
+
+## Formato de salida
+Respeta el formato `ruta\ncontenido completo`. Incluye resultados resumidos de escaneos o reportes en Markdown.
+
+## Coordinación con otros agentes
+- **Backend/Frontend**: aplicar parches y controles específicos.
+- **DevOps**: asegurar que pipelines escanean imágenes y controlan secretos.
+- **Docs**: mantener `SECURITY.md` y manuales actualizados.

--- a/instructions/agents/agent_ux.md
+++ b/instructions/agents/agent_ux.md
@@ -1,0 +1,31 @@
+# Agente UX
+
+## Objetivo
+Diseñar experiencias consistentes, accesibles y alineadas con Flowbite/Heroicons que sirvan como guía para los agentes posteriores.
+
+## Entradas requeridas
+- Contexto actualizado del proyecto (`instructions/CONTEXT.md`).
+- Tareas activas en `instructions/tasks/` relacionadas con UX.
+- Restricciones de marca, tokens y componentes reutilizables.
+
+## Entregables mínimos
+1. **Mapa de navegación** con rutas, jerarquía y estados (público vs. privado).
+2. **Wireframes de alta fidelidad textual**: describe layout, componentes Flowbite sugeridos y variantes responsivas.
+3. **Guía de accesibilidad**: contraste esperado, manejo de foco, atajos y mensajes de error.
+4. **Tokens de diseño**: paleta, tipografía, espaciados y uso de Tailwind/Flowbite documentados en JSON o Markdown.
+5. **Notas de handoff**: instrucciones claras para Frontend (nombres de componentes, props, comportamiento esperado).
+
+## Checklist operativo
+- [ ] Cubrir desktop y mobile con breakpoints de Tailwind.
+- [ ] Definir estados vacíos, cargando, éxito y error.
+- [ ] Incluir recomendaciones de copy y microinteracciones.
+- [ ] Validar accesibilidad WCAG 2.2 nivel AA.
+- [ ] Documentar dependencias con otros agentes (ej. Backend para endpoints adicionales).
+
+## Formato de salida
+Responde siguiendo la convención `ruta\ncontenido` por archivo. Si generas assets externos (por ejemplo, imágenes), proporciona la referencia relativa al repositorio.
+
+## Coordinación con otros agentes
+- **Frontend**: provee nombres de componentes y props esperadas.
+- **Backend**: solicita atributos o endpoints necesarios para cumplir flujos UX.
+- **QA**: adelanta criterios de aceptación centrados en experiencia de usuario.

--- a/instructions/tasks/2025-10-19_auth_crud_usuarios_blog.md
+++ b/instructions/tasks/2025-10-19_auth_crud_usuarios_blog.md
@@ -1,0 +1,45 @@
+# TAREA – Autenticación, Backoffice y CRUD completo (Django + React)
+
+## Objetivo
+Integrar usuarios Django con JWT y endpoints REST (login/registro), CRUD de Post/Category/Tag, backoffice protegido, email en registro, y despliegues funcionales en Pages y Dokploy.
+
+## Alcance
+- Backend Django 5 + DRF + SimpleJWT + dj-rest-auth + allauth + CORS + emails + media.
+- Frontend React + Vite + Tailwind + Flowbite + Heroicons + axios + react-hook-form + zod + react-hot-toast + rutas privadas.
+- Docker backend basado en `python:3.12-alpine` con Gunicorn, volumen `media`, SMTP y variables de entorno documentadas.
+
+## Flujo de agentes
+1. UX → Diseña flujos de autenticación, dashboard y CRUD.
+2. Frontend → Implementa UI, formularios, validaciones y consumo de API.
+3. Backend → Configura auth JWT, endpoints REST y lógica de email.
+4. QA → Automatiza pruebas unitarias, integración y e2e.
+5. DevOps → Actualiza Dockerfiles, docker-compose, GHCR y despliegues en Dokploy/Pages.
+6. Docs → Documenta README, `.env.example`, scripts y ADR si aplica.
+7. Security → Revisa permisos, CORS/CSRF, headers y gestión de secretos.
+8. Data → Genera seeds/fixtures para usuarios, categorías, posts y comentarios.
+
+## Entregables
+- [ ] Endpoints REST autenticación y CRUD operativos.
+- [ ] Interfaz web con login, registro, dashboard y formularios CRUD.
+- [ ] Pipelines de CI/CD con pruebas y build/despliegue automatizados.
+- [ ] Documentación actualizada y seeds listos.
+
+## Criterios de aceptación
+1. Registro envía email por consola y requiere verificación mínima.
+2. Login almacena tokens y permite acceso a `/dashboard` protegido.
+3. CRUD completo de Post/Category/Tag desde API y backoffice.
+4. CORS configurado para frontend en Pages; build y deploy funcionales.
+
+## Variables de entorno
+- `DJANGO_SECRET_KEY`, `DJANGO_DEBUG`, `DJANGO_ALLOWED_HOSTS`, `DJANGO_CORS_ORIGINS`, `DATABASE_URL` o variables PostgreSQL.
+- `EMAIL_HOST`, `EMAIL_PORT`, `EMAIL_HOST_USER`, `EMAIL_HOST_PASSWORD`, `EMAIL_USE_TLS`.
+- `VITE_API_BASE_URL`, `VITE_AUTH_TOKEN_KEY` para frontend.
+
+## QA rápido
+- `pytest --ds=config.settings.test`.
+- `npm test` y `npx playwright test` en frontend.
+- `docker compose up --build` y verificación manual de login/CRUD.
+
+## Notas adicionales
+- Documentar rutas privadas y roles (admin/editor/lector).
+- Incluir ejemplo de configuración SMTP local (Mailhog o consola).

--- a/instructions/tasks/TEMPLATE_TASK.md
+++ b/instructions/tasks/TEMPLATE_TASK.md
@@ -1,0 +1,41 @@
+# TAREA – {Título conciso}
+
+## Objetivo
+Describe qué se pretende lograr y cómo impacta al producto.
+
+## Alcance
+- Lista de funcionalidades o entregables incluidos.
+- Explica lo que queda explícitamente fuera de este alcance.
+
+## Flujo de agentes
+1. UX → …
+2. Frontend → …
+3. Backend → …
+4. QA → …
+5. DevOps → …
+6. Docs → …
+7. Security → …
+8. Data → …
+
+> Ajusta el orden solo si la tarea lo requiere; documenta dependencias adicionales.
+
+## Entregables
+- [ ] Archivo o carpeta 1.
+- [ ] Archivo o carpeta 2.
+- [ ] Scripts, configuraciones o migraciones.
+
+## Criterios de aceptación
+1. Describe pruebas o comandos que deben ejecutarse (incluye resultados esperados).
+2. Define comportamientos funcionales verificables.
+3. Incluye validaciones de seguridad o accesibilidad cuando aplique.
+
+## Variables de entorno
+- `CLAVE=valor` — indica uso y si es obligatoria.
+- Añade notas sobre cómo documentarlas en `.env.example`.
+
+## QA rápido
+- Comandos express (ej. `npm test`, `pytest`, `npx playwright test`).
+- Métodos manuales para validar en local.
+
+## Notas adicionales
+- Enlaces relevantes, decisiones de arquitectura o dudas abiertas.


### PR DESCRIPTION
## Summary
- formalize the multi-agent workflow under instructions/agents with dedicated guides per rol
- update instructions README and repository README to describe the reading order and environment variables
- add reusable task template and optional auth/CRUD backlog entry for Codex Cloud

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68f482e341008327b7715f8019a2a425