### PR TITLE
Add authentication API endpoints for registration and login

### DIFF
--- a/backend/accounts/__init__.py
+++ b/backend/accounts/__init__.py
@@ -1,0 +1,1 @@
+"""Accounts app providing authentication APIs."""

--- a/backend/accounts/apps.py
+++ b/backend/accounts/apps.py
@@ -1,0 +1,9 @@
+from django.apps import AppConfig
+
+
+class AccountsConfig(AppConfig):
+    """Application configuration for authentication endpoints."""
+
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "accounts"
+    verbose_name = "Accounts"

--- a/backend/accounts/serializers.py
+++ b/backend/accounts/serializers.py
@@ -1,0 +1,134 @@
+"""Serializers powering the authentication API."""
+from __future__ import annotations
+
+from typing import Any
+
+from django.contrib.auth import authenticate, get_user_model
+from django.contrib.auth.password_validation import validate_password
+from django.utils.translation import gettext_lazy as _
+from rest_framework import serializers
+from rest_framework_simplejwt.tokens import RefreshToken
+
+User = get_user_model()
+
+
+class UserSerializer(serializers.ModelSerializer):
+    """Public representation for authenticated users."""
+
+    class Meta:
+        model = User
+        fields = ["id", "username", "email", "first_name", "last_name"]
+        read_only_fields = fields
+
+
+class RegisterSerializer(serializers.ModelSerializer):
+    """Handle user creation with password validation."""
+
+    password1 = serializers.CharField(write_only=True, style={"input_type": "password"})
+    password2 = serializers.CharField(write_only=True, style={"input_type": "password"})
+
+    class Meta:
+        model = User
+        fields = [
+            "username",
+            "email",
+            "first_name",
+            "last_name",
+            "password1",
+            "password2",
+        ]
+
+    default_error_messages = {
+        "password_mismatch": _("Las contraseñas no coinciden."),
+        "invalid_credentials": _("No se pudieron validar las credenciales."),
+    }
+
+    def validate_email(self, value: str) -> str:
+        """Ensure the email address is unique."""
+
+        value = value.strip()
+        if not value:
+            raise serializers.ValidationError(_("El correo electrónico es obligatorio."))
+        if User.objects.filter(email__iexact=value).exists():
+            raise serializers.ValidationError(_("Ya existe un usuario con este correo."))
+        return value
+
+    def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
+        password1 = attrs.get("password1")
+        password2 = attrs.get("password2")
+
+        if password1 != password2:
+            self.fail("password_mismatch")
+
+        temp_user = User(
+            username=attrs.get("username"),
+            email=attrs.get("email"),
+            first_name=attrs.get("first_name", ""),
+            last_name=attrs.get("last_name", ""),
+        )
+        validate_password(password1, user=temp_user)
+        return attrs
+
+    def create(self, validated_data: dict[str, Any]) -> User:
+        password = validated_data.pop("password1")
+        validated_data.pop("password2", None)
+        user = User.objects.create_user(password=password, **validated_data)
+        return user
+
+    def to_representation(self, instance: User) -> dict[str, Any]:
+        """Include JWT tokens alongside the public user data."""
+
+        refresh = RefreshToken.for_user(instance)
+        return {
+            "user": UserSerializer(instance).data,
+            "refresh": str(refresh),
+            "access": str(refresh.access_token),
+        }
+
+
+class LoginSerializer(serializers.Serializer):
+    """Authenticate using username or email and return JWT tokens."""
+
+    username = serializers.CharField(required=False, allow_blank=True)
+    email = serializers.EmailField(required=False, allow_blank=True)
+    password = serializers.CharField(write_only=True, style={"input_type": "password"})
+
+    default_error_messages = {
+        "invalid_credentials": _("Credenciales inválidas."),
+        "inactive": _("La cuenta está inactiva."),
+    }
+
+    def _authenticate_with_identifier(self, *, identifier: str, password: str) -> User | None:
+        """Try authenticating with either username or email."""
+
+        request = self.context.get("request")
+        user = authenticate(request=request, username=identifier, password=password)
+        if user is not None:
+            return user
+        try:
+            user_obj = User.objects.get(email__iexact=identifier)
+        except User.DoesNotExist:
+            return None
+        return authenticate(request=request, username=user_obj.get_username(), password=password)
+
+    def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
+        password = attrs.get("password")
+        identifier = attrs.get("username") or attrs.get("email")
+
+        if not identifier or not password:
+            raise serializers.ValidationError(self.error_messages["invalid_credentials"])
+
+        user = self._authenticate_with_identifier(identifier=identifier, password=password)
+
+        if user is None:
+            raise serializers.ValidationError(self.error_messages["invalid_credentials"])
+
+        if not user.is_active:
+            raise serializers.ValidationError(self.error_messages["inactive"])
+
+        refresh = RefreshToken.for_user(user)
+        return {
+            "user": UserSerializer(user).data,
+            "refresh": str(refresh),
+            "access": str(refresh.access_token),
+        }

--- a/backend/accounts/urls.py
+++ b/backend/accounts/urls.py
@@ -1,0 +1,14 @@
+"""URL configuration for authentication endpoints."""
+from __future__ import annotations
+
+from django.urls import path
+
+from .views import LoginAPIView, RegisterAPIView, UserProfileAPIView
+
+app_name = "accounts"
+
+urlpatterns = [
+    path("registration/", RegisterAPIView.as_view(), name="registration"),
+    path("login/", LoginAPIView.as_view(), name="login"),
+    path("user/", UserProfileAPIView.as_view(), name="user"),
+]

--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -1,0 +1,69 @@
+"""Authentication API views."""
+from __future__ import annotations
+
+from django.conf import settings
+from django.core.mail import send_mail
+from drf_spectacular.utils import extend_schema
+from rest_framework import generics, permissions, status
+from rest_framework.response import Response
+
+from .serializers import LoginSerializer, RegisterSerializer, UserSerializer
+
+
+@extend_schema(tags=["auth"])
+class RegisterAPIView(generics.GenericAPIView):
+    """Register a new user and return JWT tokens."""
+
+    serializer_class = RegisterSerializer
+    permission_classes = [permissions.AllowAny]
+
+    @extend_schema(
+        summary="Registrar nuevo usuario",
+        description="Crea una cuenta y devuelve los tokens JWT iniciales.",
+    )
+    def post(self, request, *args, **kwargs):
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        user = serializer.save()
+        self._send_welcome_email(user)
+        return Response(serializer.to_representation(user), status=status.HTTP_201_CREATED)
+
+    def _send_welcome_email(self, user) -> None:
+        if not user.email:
+            return
+        subject = "Bienvenido a CodexTest"
+        message = (
+            "Hola {name},\n\n"
+            "Gracias por registrarte en CodexTest. Ya puedes iniciar sesión con tus credenciales."
+        ).format(name=user.get_full_name() or user.get_username())
+        send_mail(subject, message, settings.DEFAULT_FROM_EMAIL, [user.email], fail_silently=False)
+
+
+@extend_schema(tags=["auth"])
+class LoginAPIView(generics.GenericAPIView):
+    """Issue JWT tokens after validating credentials."""
+
+    serializer_class = LoginSerializer
+    permission_classes = [permissions.AllowAny]
+
+    @extend_schema(summary="Iniciar sesión", description="Devuelve tokens JWT válidos")
+    def post(self, request, *args, **kwargs):
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        return Response(serializer.validated_data, status=status.HTTP_200_OK)
+
+
+@extend_schema(tags=["auth"])
+class UserProfileAPIView(generics.RetrieveAPIView):
+    """Return information about the currently authenticated user."""
+
+    serializer_class = UserSerializer
+    permission_classes = [permissions.IsAuthenticated]
+
+    @extend_schema(summary="Perfil de usuario", description="Devuelve los datos del usuario autenticado")
+    def get(self, request, *args, **kwargs):  # type: ignore[override]
+        serializer = self.get_serializer(request.user)
+        return Response(serializer.data)
+
+    def get_object(self):  # type: ignore[override]
+        return self.request.user

--- a/backend/backendblog/settings.py
+++ b/backend/backendblog/settings.py
@@ -58,6 +58,7 @@ INSTALLED_APPS = [
     "allauth",
     "allauth.account",
     "allauth.socialaccount",
+    "accounts.apps.AccountsConfig",
     "blog.apps.BlogConfig",
 ]
 

--- a/backend/backendblog/urls.py
+++ b/backend/backendblog/urls.py
@@ -12,8 +12,7 @@ from rest_framework_simplejwt.views import TokenRefreshView
 
 urlpatterns = [
     path("admin/", admin.site.urls),
-    path("api/auth/", include("dj_rest_auth.urls")),
-    path("api/auth/registration/", include("dj_rest_auth.registration.urls")),
+    path("api/auth/", include(("accounts.urls", "accounts"), namespace="accounts")),
     path(
         "api/auth/token/refresh/",
         TokenRefreshView.as_view(),


### PR DESCRIPTION
## Summary
- add a dedicated `accounts` app with serializers, views, and URLs for registration, login, and profile retrieval
- wire the new authentication endpoints into the project URL configuration and install the app

## Testing
- DJANGO_SETTINGS_MODULE=settings_test python manage.py test accounts tests blog

------
https://chatgpt.com/codex/tasks/task_e_68f48f7156fc8327996b20d47df55bc5