### PR TITLE
feat: add dashboard crud for posts categories and tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ Monorepo que integra frontend (React + Vite), backend (Django REST Framework) y 
 - Tailwind CSS v4 (o fallback 3.4.x documentado) con Flowbite y Heroicons.
 - Gestión de estado ligera con stores o React Query según la tarea.
 - Formularios con `react-hook-form` + `zod` y notificaciones `react-hot-toast`.
+- Panel de backoffice protegido bajo `/dashboard` con CRUD completo de posts, categorías y tags.
+- Tablas responsivas con `@tanstack/react-table`, multiselect con `react-select`, editor enriquecido con `react-quill` y slugs generados con `slugify`.
+- Subida de imágenes a través de `multipart/form-data`; requiere que el backend exponga `/media/` y haya sesión iniciada para adjuntar tokens JWT.
 
 ### Backend
 - Django 5 estructurado en múltiples apps (`users`, `blog`, `core`).

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -10,6 +10,13 @@ import Login from './pages/Login.jsx';
 import Register from './pages/Register.jsx';
 import Profile from './pages/Profile.jsx';
 import ProtectedRoute from './routes/ProtectedRoute.jsx';
+import Dashboard from './pages/dashboard/Dashboard.jsx';
+import PostsList from './pages/dashboard/PostsList.jsx';
+import PostForm from './pages/dashboard/PostForm.jsx';
+import CategoriesList from './pages/dashboard/CategoriesList.jsx';
+import CategoryForm from './pages/dashboard/CategoryForm.jsx';
+import TagsList from './pages/dashboard/TagsList.jsx';
+import TagForm from './pages/dashboard/TagForm.jsx';
 import {
   SITE_NAME,
   SITE_DESCRIPTION,
@@ -50,6 +57,86 @@ function App() {
               element={(
                 <ProtectedRoute>
                   <Profile />
+                </ProtectedRoute>
+              )}
+            />
+            <Route
+              path="/dashboard"
+              element={(
+                <ProtectedRoute>
+                  <Dashboard />
+                </ProtectedRoute>
+              )}
+            />
+            <Route
+              path="/dashboard/posts"
+              element={(
+                <ProtectedRoute>
+                  <PostsList />
+                </ProtectedRoute>
+              )}
+            />
+            <Route
+              path="/dashboard/posts/new"
+              element={(
+                <ProtectedRoute>
+                  <PostForm />
+                </ProtectedRoute>
+              )}
+            />
+            <Route
+              path="/dashboard/posts/:id/edit"
+              element={(
+                <ProtectedRoute>
+                  <PostForm />
+                </ProtectedRoute>
+              )}
+            />
+            <Route
+              path="/dashboard/categories"
+              element={(
+                <ProtectedRoute>
+                  <CategoriesList />
+                </ProtectedRoute>
+              )}
+            />
+            <Route
+              path="/dashboard/categories/new"
+              element={(
+                <ProtectedRoute>
+                  <CategoryForm />
+                </ProtectedRoute>
+              )}
+            />
+            <Route
+              path="/dashboard/categories/:id/edit"
+              element={(
+                <ProtectedRoute>
+                  <CategoryForm />
+                </ProtectedRoute>
+              )}
+            />
+            <Route
+              path="/dashboard/tags"
+              element={(
+                <ProtectedRoute>
+                  <TagsList />
+                </ProtectedRoute>
+              )}
+            />
+            <Route
+              path="/dashboard/tags/new"
+              element={(
+                <ProtectedRoute>
+                  <TagForm />
+                </ProtectedRoute>
+              )}
+            />
+            <Route
+              path="/dashboard/tags/:id/edit"
+              element={(
+                <ProtectedRoute>
+                  <TagForm />
                 </ProtectedRoute>
               )}
             />

--- a/frontend/src/components/DataTable.jsx
+++ b/frontend/src/components/DataTable.jsx
@@ -1,0 +1,202 @@
+import { useMemo, useState } from 'react';
+import PropTypes from 'prop-types';
+import {
+  flexRender,
+  getCoreRowModel,
+  getSortedRowModel,
+  useReactTable
+} from '@tanstack/react-table';
+import { Table, Spinner, Pagination as FlowbitePagination } from 'flowbite-react';
+import {
+  Bars3Icon,
+  ChevronDownIcon,
+  ChevronUpIcon
+} from '@heroicons/react/24/outline';
+
+function DataTable({
+  columns,
+  data,
+  toolbar,
+  onRowClick,
+  emptyMessage = 'No hay datos disponibles.',
+  isLoading = false,
+  manualSorting = false,
+  onSortingChange,
+  initialSorting,
+  pagination
+}) {
+  const [localSorting, setLocalSorting] = useState(initialSorting ?? []);
+
+  const sortingState = manualSorting ? initialSorting ?? [] : localSorting;
+
+  const table = useReactTable({
+    data,
+    columns,
+    state: {
+      sorting: sortingState
+    },
+    manualSorting,
+    onSortingChange: manualSorting
+      ? onSortingChange
+      : (updater) => {
+          const nextSorting = typeof updater === 'function' ? updater(localSorting) : updater;
+          setLocalSorting(nextSorting);
+        },
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: manualSorting ? undefined : getSortedRowModel()
+  });
+
+  const isServerPagination = pagination?.mode === 'server';
+  const currentPage = pagination?.pageIndex ?? 0;
+  const pageSize = pagination?.pageSize ?? data.length;
+  const pageCount = pagination?.pageCount ?? 1;
+
+  const pageItems = useMemo(() => {
+    if (!pagination || isServerPagination) {
+      return table.getRowModel().rows;
+    }
+
+    const start = currentPage * pageSize;
+    const end = start + pageSize;
+    return table.getRowModel().rows.slice(start, end);
+  }, [currentPage, pageSize, pagination, table]);
+
+  const visibleColumns = table.getVisibleLeafColumns().length;
+
+  return (
+    <div className="flex flex-col gap-4">
+      {toolbar ? <div className="flex flex-wrap items-center justify-between gap-3">{toolbar}</div> : null}
+      <div className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm transition-colors duration-300 dark:border-slate-800 dark:bg-slate-900">
+        <div className="overflow-x-auto">
+          <Table className="min-w-full divide-y divide-slate-200 text-left text-sm text-slate-600 dark:divide-slate-800 dark:text-slate-300">
+            <Table.Head className="bg-slate-50/80 dark:bg-slate-900/60">
+              {table.getHeaderGroups().map((headerGroup) =>
+                headerGroup.headers.map((header) => {
+                  if (header.isPlaceholder) {
+                    return null;
+                  }
+
+                  const canSort = header.column.getCanSort();
+                  const sorting = header.column.getIsSorted();
+                  const SortingIcon = sorting === 'asc' ? ChevronUpIcon : sorting === 'desc' ? ChevronDownIcon : Bars3Icon;
+
+                  return (
+                    <Table.HeadCell key={header.id} className="px-4 py-3 text-xs font-semibold uppercase tracking-wide">
+                      <button
+                        type="button"
+                        onClick={canSort ? header.column.getToggleSortingHandler() : undefined}
+                        className={`flex items-center gap-2 rounded-md px-2 py-1 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-900 ${
+                          canSort ? 'hover:bg-slate-100 dark:hover:bg-slate-800' : 'cursor-default'
+                        }`}
+                        aria-label={
+                          canSort
+                            ? `Ordenar por ${flexRender(header.column.columnDef.header, header.getContext())}`
+                            : undefined
+                        }
+                        disabled={!canSort}
+                      >
+                        <span className="text-xs font-semibold uppercase tracking-wider text-slate-500 dark:text-slate-400">
+                          {flexRender(header.column.columnDef.header, header.getContext())}
+                        </span>
+                        {canSort ? (
+                          <SortingIcon className="h-4 w-4 text-slate-400" aria-hidden="true" />
+                        ) : null}
+                      </button>
+                    </Table.HeadCell>
+                  );
+                })
+              )}
+            </Table.Head>
+            <Table.Body className="divide-y divide-slate-200 dark:divide-slate-800">
+              {isLoading ? (
+                <Table.Row>
+                  <Table.Cell
+                    colSpan={visibleColumns}
+                    className="px-6 py-10 text-center text-sm text-slate-500 dark:text-slate-400"
+                  >
+                    <div className="flex flex-col items-center justify-center gap-3" role="status" aria-live="polite">
+                      <Spinner aria-label="Cargando tabla" />
+                      <span>Cargando información...</span>
+                    </div>
+                  </Table.Cell>
+                </Table.Row>
+              ) : pageItems.length === 0 ? (
+                <Table.Row>
+                  <Table.Cell
+                    colSpan={visibleColumns}
+                    className="px-6 py-10 text-center text-sm text-slate-500 dark:text-slate-400"
+                  >
+                    {emptyMessage}
+                  </Table.Cell>
+                </Table.Row>
+              ) : (
+                pageItems.map((row) => (
+                  <Table.Row
+                    key={row.id}
+                    className={`group bg-white transition-colors duration-200 dark:bg-slate-900 ${
+                      onRowClick ? 'cursor-pointer hover:bg-slate-50 dark:hover:bg-slate-800' : ''
+                    }`}
+                    onClick={onRowClick ? () => onRowClick(row.original) : undefined}
+                  >
+                    {row.getVisibleCells().map((cell) => (
+                      <Table.Cell key={cell.id} className="px-4 py-3 text-sm">
+                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                      </Table.Cell>
+                    ))}
+                  </Table.Row>
+                ))
+              )}
+            </Table.Body>
+          </Table>
+        </div>
+      </div>
+      {pagination ? (
+        <div className="flex items-center justify-end gap-6">
+          <p className="text-sm text-slate-500 dark:text-slate-400">
+            Mostrando{' '}
+            <span className="font-semibold text-slate-700 dark:text-slate-200">
+              {pageItems.length > 0 ? currentPage * pageSize + 1 : 0}
+            </span>{' '}
+            -{' '}
+            <span className="font-semibold text-slate-700 dark:text-slate-200">
+              {currentPage * pageSize + pageItems.length}
+            </span>{' '}
+            de{' '}
+            <span className="font-semibold text-slate-700 dark:text-slate-200">
+              {pagination.totalItems ?? data.length}
+            </span>
+          </p>
+          <FlowbitePagination
+            currentPage={currentPage + 1}
+            totalPages={pageCount}
+            onPageChange={(page) => pagination.onPageChange?.(page - 1)}
+            showIcons
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+DataTable.propTypes = {
+  columns: PropTypes.arrayOf(PropTypes.object).isRequired,
+  data: PropTypes.arrayOf(PropTypes.object).isRequired,
+  toolbar: PropTypes.node,
+  onRowClick: PropTypes.func,
+  emptyMessage: PropTypes.string,
+  isLoading: PropTypes.bool,
+  manualSorting: PropTypes.bool,
+  onSortingChange: PropTypes.func,
+  initialSorting: PropTypes.arrayOf(PropTypes.object),
+  pagination: PropTypes.shape({
+    pageIndex: PropTypes.number,
+    pageSize: PropTypes.number,
+    pageCount: PropTypes.number,
+    onPageChange: PropTypes.func,
+    totalItems: PropTypes.number,
+    mode: PropTypes.oneOf(['client', 'server'])
+  })
+};
+
+export default DataTable;
+

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -81,6 +81,9 @@ function Navbar() {
       arrowIcon={false}
       inline
     >
+      <Dropdown.Item as={Link} to="/dashboard" icon={BoltIcon}>
+        Dashboard
+      </Dropdown.Item>
       <Dropdown.Item as={Link} to="/profile" icon={UserCircleIcon}>
         Perfil
       </Dropdown.Item>
@@ -174,6 +177,17 @@ function Navbar() {
           <ClockIcon className="h-5 w-5" aria-hidden="true" />
           Timeline
         </FlowbiteNavbar.Link>
+        {isAuthenticated ? (
+          <FlowbiteNavbar.Link
+            as={Link}
+            to="/dashboard"
+            active={location.pathname.startsWith('/dashboard')}
+            className="flex items-center gap-2 text-base text-slate-600 transition duration-300 hover:text-sky-600 dark:text-slate-300 dark:hover:text-sky-300"
+          >
+            <BoltIcon className="h-5 w-5" aria-hidden="true" />
+            Dashboard
+          </FlowbiteNavbar.Link>
+        ) : null}
         <form
           role="search"
           className="md:hidden"
@@ -204,6 +218,15 @@ function Navbar() {
         {isLoading ? null : (
           isAuthenticated ? (
             <div className="flex flex-col gap-2">
+              {isAuthenticated ? (
+                <FlowbiteNavbar.Link
+                  as={Link}
+                  to="/dashboard"
+                  className="text-base text-slate-600 transition hover:text-sky-600 dark:text-slate-300 dark:hover:text-sky-300"
+                >
+                  Dashboard
+                </FlowbiteNavbar.Link>
+              ) : null}
               <FlowbiteNavbar.Link as={Link} to="/profile" className="text-base text-slate-600 transition hover:text-sky-600 dark:text-slate-300 dark:hover:text-sky-300">
                 Perfil
               </FlowbiteNavbar.Link>

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -1,0 +1,75 @@
+import { Sidebar } from 'flowbite-react';
+import {
+  HomeModernIcon,
+  NewspaperIcon,
+  TagIcon,
+  Squares2X2Icon,
+  UserCircleIcon
+} from '@heroicons/react/24/outline';
+import { Link, useLocation } from 'react-router-dom';
+
+const items = [
+  {
+    label: 'Resumen',
+    to: '/dashboard',
+    icon: HomeModernIcon
+  },
+  {
+    label: 'Posts',
+    to: '/dashboard/posts',
+    icon: NewspaperIcon
+  },
+  {
+    label: 'Categorías',
+    to: '/dashboard/categories',
+    icon: Squares2X2Icon
+  },
+  {
+    label: 'Tags',
+    to: '/dashboard/tags',
+    icon: TagIcon
+  },
+  {
+    label: 'Perfil',
+    to: '/profile',
+    icon: UserCircleIcon
+  }
+];
+
+function DashboardSidebar() {
+  const location = useLocation();
+
+  return (
+    <aside className="hidden w-64 shrink-0 lg:block">
+      <Sidebar aria-label="Menú de administración" className="h-full rounded-xl border border-slate-200 bg-white/90 shadow-sm backdrop-blur dark:border-slate-800 dark:bg-slate-900/80">
+        <Sidebar.Items>
+          <Sidebar.ItemGroup>
+            {items.map((item) => {
+              const Icon = item.icon;
+              const isActive = location.pathname === item.to || location.pathname.startsWith(`${item.to}/`);
+              return (
+                <Sidebar.Item
+                  key={item.to}
+                  as={Link}
+                  to={item.to}
+                  icon={Icon}
+                  className={
+                    isActive
+                      ? 'bg-sky-100 text-sky-700 hover:bg-sky-100 dark:bg-sky-900/40 dark:text-sky-300'
+                      : 'text-slate-600 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800'
+                  }
+                  active={isActive}
+                >
+                  {item.label}
+                </Sidebar.Item>
+              );
+            })}
+          </Sidebar.ItemGroup>
+        </Sidebar.Items>
+      </Sidebar>
+    </aside>
+  );
+}
+
+export default DashboardSidebar;
+

--- a/frontend/src/components/forms/FileUpload.jsx
+++ b/frontend/src/components/forms/FileUpload.jsx
@@ -1,0 +1,106 @@
+import PropTypes from 'prop-types';
+import { Controller } from 'react-hook-form';
+import { Label, FileInput, HelperText, Button } from 'flowbite-react';
+import { ExclamationCircleIcon, XMarkIcon } from '@heroicons/react/24/outline';
+
+function FileUpload({
+  control,
+  name,
+  label,
+  helperText,
+  description,
+  rules,
+  accept,
+  onClear,
+  clearLabel = 'Quitar archivo'
+}) {
+  const fieldId = name;
+  const helperId = helperText ? `${fieldId}-helper` : undefined;
+
+  return (
+    <Controller
+      name={name}
+      control={control}
+      rules={rules}
+      render={({ field, fieldState }) => {
+        const value = field.value;
+        const fileName = value instanceof File ? value.name : typeof value === 'string' ? value : '';
+
+        return (
+          <div className="flex flex-col gap-1.5">
+            {label ? (
+              <Label htmlFor={fieldId} className="text-sm font-medium text-slate-700 dark:text-slate-200">
+                {label}
+              </Label>
+            ) : null}
+            {description ? (
+              <p id={`${fieldId}-description`} className="text-xs text-slate-500 dark:text-slate-400">
+                {description}
+              </p>
+            ) : null}
+            <FileInput
+              id={fieldId}
+              accept={accept}
+              onChange={(event) => {
+                const file = event.target.files?.[0] ?? null;
+                field.onChange(file);
+              }}
+              color={fieldState.invalid ? 'failure' : undefined}
+              aria-invalid={fieldState.invalid}
+              aria-describedby={[helperId, description ? `${fieldId}-description` : null]
+                .filter(Boolean)
+                .join(' ')}
+            />
+            {fileName ? (
+              <div className="flex items-center justify-between rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-xs text-slate-600 dark:border-slate-800 dark:bg-slate-900/40 dark:text-slate-300">
+                <span className="truncate" title={fileName}>
+                  {fileName}
+                </span>
+                {onClear ? (
+                  <Button
+                    color="light"
+                    size="xs"
+                    type="button"
+                    onClick={() => {
+                      onClear();
+                      field.onChange(null);
+                    }}
+                    className="flex items-center gap-1"
+                  >
+                    <XMarkIcon className="h-4 w-4" aria-hidden="true" />
+                    {clearLabel}
+                  </Button>
+                ) : null}
+              </div>
+            ) : null}
+            {fieldState.error ? (
+              <HelperText id={helperId} color="failure" className="flex items-center gap-2 text-xs">
+                <ExclamationCircleIcon className="h-4 w-4" aria-hidden="true" />
+                <span>{fieldState.error.message}</span>
+              </HelperText>
+            ) : helperText ? (
+              <HelperText id={helperId} className="text-xs text-slate-500 dark:text-slate-400">
+                {helperText}
+              </HelperText>
+            ) : null}
+          </div>
+        );
+      }}
+    />
+  );
+}
+
+FileUpload.propTypes = {
+  control: PropTypes.object.isRequired,
+  name: PropTypes.string.isRequired,
+  label: PropTypes.node,
+  helperText: PropTypes.node,
+  description: PropTypes.node,
+  rules: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
+  accept: PropTypes.string,
+  onClear: PropTypes.func,
+  clearLabel: PropTypes.string
+};
+
+export default FileUpload;
+

--- a/frontend/src/components/forms/Input.jsx
+++ b/frontend/src/components/forms/Input.jsx
@@ -1,0 +1,64 @@
+import PropTypes from 'prop-types';
+import { Controller } from 'react-hook-form';
+import { Label, TextInput, HelperText } from 'flowbite-react';
+import { ExclamationCircleIcon } from '@heroicons/react/24/outline';
+
+function Input({ control, name, label, helperText, rules, description, ...rest }) {
+  const fieldId = rest.id ?? name;
+  const helperId = helperText ? `${fieldId}-helper` : undefined;
+
+  return (
+    <Controller
+      name={name}
+      control={control}
+      rules={rules}
+      render={({ field, fieldState }) => (
+        <div className="flex flex-col gap-1.5">
+          {label ? (
+            <Label htmlFor={fieldId} className="text-sm font-medium text-slate-700 dark:text-slate-200">
+              {label}
+            </Label>
+          ) : null}
+          {description ? (
+            <p id={`${fieldId}-description`} className="text-xs text-slate-500 dark:text-slate-400">
+              {description}
+            </p>
+          ) : null}
+          <TextInput
+            {...rest}
+            {...field}
+            id={fieldId}
+            color={fieldState.invalid ? 'failure' : undefined}
+            aria-invalid={fieldState.invalid}
+            aria-describedby={[helperId, description ? `${fieldId}-description` : null]
+              .filter(Boolean)
+              .join(' ')}
+            helperText={undefined}
+          />
+          {fieldState.error ? (
+            <HelperText id={helperId} color="failure" className="flex items-center gap-2 text-xs">
+              <ExclamationCircleIcon className="h-4 w-4" aria-hidden="true" />
+              <span>{fieldState.error.message}</span>
+            </HelperText>
+          ) : helperText ? (
+            <HelperText id={helperId} className="text-xs text-slate-500 dark:text-slate-400">
+              {helperText}
+            </HelperText>
+          ) : null}
+        </div>
+      )}
+    />
+  );
+}
+
+Input.propTypes = {
+  control: PropTypes.object.isRequired,
+  name: PropTypes.string.isRequired,
+  label: PropTypes.node,
+  helperText: PropTypes.node,
+  rules: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
+  description: PropTypes.node
+};
+
+export default Input;
+

--- a/frontend/src/components/forms/MultiSelect.jsx
+++ b/frontend/src/components/forms/MultiSelect.jsx
@@ -1,0 +1,150 @@
+import PropTypes from 'prop-types';
+import { Controller } from 'react-hook-form';
+import Select from 'react-select';
+import { Label, HelperText } from 'flowbite-react';
+import { ExclamationCircleIcon } from '@heroicons/react/24/outline';
+
+const createSelectStyles = (isDarkMode) => ({
+  control: (provided, state) => ({
+    ...provided,
+    backgroundColor: isDarkMode ? 'rgba(15,23,42,0.7)' : 'transparent',
+    borderColor: state.isFocused
+      ? 'rgb(14 165 233 / 0.8)'
+      : state.hasValue
+        ? isDarkMode
+          ? 'rgba(148, 163, 184, 0.5)'
+          : 'rgb(148 163 184 / 0.6)'
+        : isDarkMode
+          ? 'rgba(71, 85, 105, 0.8)'
+          : 'rgb(226 232 240)',
+    boxShadow: state.isFocused ? '0 0 0 2px rgb(14 165 233 / 0.25)' : 'none',
+    color: isDarkMode ? 'rgb(226 232 240)' : 'rgb(15 23 42)',
+    transition: 'all 150ms ease',
+    borderWidth: '1px'
+  }),
+  multiValue: (provided) => ({
+    ...provided,
+    backgroundColor: isDarkMode ? 'rgba(56,189,248,0.25)' : 'rgb(14 165 233 / 0.15)',
+    color: isDarkMode ? 'rgb(125 211 252)' : 'rgb(14 116 144)'
+  }),
+  multiValueLabel: (provided) => ({
+    ...provided,
+    color: isDarkMode ? 'rgb(191 219 254)' : provided.color
+  }),
+  option: (provided, state) => ({
+    ...provided,
+    backgroundColor: state.isSelected
+      ? 'rgb(14 165 233 / 0.25)'
+      : state.isFocused
+        ? 'rgb(14 165 233 / 0.15)'
+        : isDarkMode
+          ? 'rgba(15,23,42,0.95)'
+          : 'transparent',
+    color: isDarkMode ? 'rgb(226 232 240)' : 'rgb(15 23 42)'
+  }),
+  placeholder: (provided) => ({
+    ...provided,
+    color: isDarkMode ? 'rgb(148 163 184)' : 'rgb(100 116 139)'
+  }),
+  singleValue: (provided) => ({
+    ...provided,
+    color: isDarkMode ? 'rgb(226 232 240)' : 'rgb(15 23 42)'
+  }),
+  input: (provided) => ({
+    ...provided,
+    color: isDarkMode ? 'rgb(226 232 240)' : 'rgb(15 23 42)'
+  }),
+  menu: (provided) => ({
+    ...provided,
+    backgroundColor: isDarkMode ? 'rgba(15,23,42,0.95)' : 'white',
+    zIndex: 50
+  })
+});
+
+function MultiSelect({
+  control,
+  name,
+  label,
+  helperText,
+  rules,
+  description,
+  options,
+  placeholder = 'Selecciona una opción',
+  isClearable = false,
+  ...rest
+}) {
+  const fieldId = rest.id ?? name;
+  const helperId = helperText ? `${fieldId}-helper` : undefined;
+  const isDarkMode =
+    typeof document !== 'undefined' && document.documentElement.classList.contains('dark');
+  const selectStyles = createSelectStyles(isDarkMode);
+
+  return (
+    <Controller
+      name={name}
+      control={control}
+      rules={rules}
+      render={({ field, fieldState }) => (
+        <div className="flex flex-col gap-1.5">
+          {label ? (
+            <Label htmlFor={fieldId} className="text-sm font-medium text-slate-700 dark:text-slate-200">
+              {label}
+            </Label>
+          ) : null}
+          {description ? (
+            <p id={`${fieldId}-description`} className="text-xs text-slate-500 dark:text-slate-400">
+              {description}
+            </p>
+          ) : null}
+          <Select
+            {...rest}
+            {...field}
+            inputId={fieldId}
+            isMulti
+            options={options}
+            placeholder={placeholder}
+            onChange={(value) => field.onChange(value)}
+            value={field.value ?? []}
+            styles={selectStyles}
+            isClearable={isClearable}
+            classNamePrefix="codex-multiselect"
+            aria-invalid={fieldState.invalid}
+            aria-describedby={[helperId, description ? `${fieldId}-description` : null]
+              .filter(Boolean)
+              .join(' ')}
+          />
+          {fieldState.error ? (
+            <HelperText id={helperId} color="failure" className="flex items-center gap-2 text-xs">
+              <ExclamationCircleIcon className="h-4 w-4" aria-hidden="true" />
+              <span>{fieldState.error.message}</span>
+            </HelperText>
+          ) : helperText ? (
+            <HelperText id={helperId} className="text-xs text-slate-500 dark:text-slate-400">
+              {helperText}
+            </HelperText>
+          ) : null}
+        </div>
+      )}
+    />
+  );
+}
+
+MultiSelect.propTypes = {
+  control: PropTypes.object.isRequired,
+  name: PropTypes.string.isRequired,
+  label: PropTypes.node,
+  helperText: PropTypes.node,
+  rules: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
+  description: PropTypes.node,
+  options: PropTypes.arrayOf(
+    PropTypes.shape({
+      value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+      label: PropTypes.string.isRequired
+    })
+  ).isRequired,
+  placeholder: PropTypes.string,
+  isClearable: PropTypes.bool
+};
+
+export default MultiSelect;
+

--- a/frontend/src/components/forms/Select.jsx
+++ b/frontend/src/components/forms/Select.jsx
@@ -1,0 +1,73 @@
+import PropTypes from 'prop-types';
+import { Controller } from 'react-hook-form';
+import { Label, Select as FlowbiteSelect, HelperText } from 'flowbite-react';
+import { ExclamationCircleIcon } from '@heroicons/react/24/outline';
+
+function Select({ control, name, label, helperText, rules, description, children, placeholder, ...rest }) {
+  const fieldId = rest.id ?? name;
+  const helperId = helperText ? `${fieldId}-helper` : undefined;
+
+  return (
+    <Controller
+      name={name}
+      control={control}
+      rules={rules}
+      render={({ field, fieldState }) => (
+        <div className="flex flex-col gap-1.5">
+          {label ? (
+            <Label htmlFor={fieldId} className="text-sm font-medium text-slate-700 dark:text-slate-200">
+              {label}
+            </Label>
+          ) : null}
+          {description ? (
+            <p id={`${fieldId}-description`} className="text-xs text-slate-500 dark:text-slate-400">
+              {description}
+            </p>
+          ) : null}
+          <FlowbiteSelect
+            {...rest}
+            {...field}
+            id={fieldId}
+            value={field.value ?? ''}
+            aria-invalid={fieldState.invalid}
+            aria-describedby={[helperId, description ? `${fieldId}-description` : null]
+              .filter(Boolean)
+              .join(' ')}
+            color={fieldState.invalid ? 'failure' : undefined}
+          >
+            {placeholder ? (
+              <option value="" disabled>
+                {placeholder}
+              </option>
+            ) : null}
+            {children}
+          </FlowbiteSelect>
+          {fieldState.error ? (
+            <HelperText id={helperId} color="failure" className="flex items-center gap-2 text-xs">
+              <ExclamationCircleIcon className="h-4 w-4" aria-hidden="true" />
+              <span>{fieldState.error.message}</span>
+            </HelperText>
+          ) : helperText ? (
+            <HelperText id={helperId} className="text-xs text-slate-500 dark:text-slate-400">
+              {helperText}
+            </HelperText>
+          ) : null}
+        </div>
+      )}
+    />
+  );
+}
+
+Select.propTypes = {
+  control: PropTypes.object.isRequired,
+  name: PropTypes.string.isRequired,
+  label: PropTypes.node,
+  helperText: PropTypes.node,
+  rules: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
+  description: PropTypes.node,
+  children: PropTypes.node,
+  placeholder: PropTypes.string
+};
+
+export default Select;
+

--- a/frontend/src/components/forms/Switch.jsx
+++ b/frontend/src/components/forms/Switch.jsx
@@ -1,0 +1,58 @@
+import PropTypes from 'prop-types';
+import { Controller } from 'react-hook-form';
+import { ToggleSwitch, HelperText } from 'flowbite-react';
+import { ExclamationCircleIcon } from '@heroicons/react/24/outline';
+
+function Switch({ control, name, label, helperText, rules, description }) {
+  const fieldId = name;
+  const helperId = helperText ? `${fieldId}-helper` : undefined;
+
+  return (
+    <Controller
+      name={name}
+      control={control}
+      rules={rules}
+      render={({ field, fieldState }) => (
+        <div className="flex flex-col gap-1.5">
+          <ToggleSwitch
+            id={fieldId}
+            checked={Boolean(field.value)}
+            label={label}
+            onChange={(checked) => field.onChange(checked)}
+            aria-describedby={[helperId, description ? `${fieldId}-description` : null]
+              .filter(Boolean)
+              .join(' ')}
+            color={fieldState.invalid ? 'red' : 'blue'}
+          />
+          {description ? (
+            <p id={`${fieldId}-description`} className="text-xs text-slate-500 dark:text-slate-400">
+              {description}
+            </p>
+          ) : null}
+          {fieldState.error ? (
+            <HelperText id={helperId} color="failure" className="flex items-center gap-2 text-xs">
+              <ExclamationCircleIcon className="h-4 w-4" aria-hidden="true" />
+              <span>{fieldState.error.message}</span>
+            </HelperText>
+          ) : helperText ? (
+            <HelperText id={helperId} className="text-xs text-slate-500 dark:text-slate-400">
+              {helperText}
+            </HelperText>
+          ) : null}
+        </div>
+      )}
+    />
+  );
+}
+
+Switch.propTypes = {
+  control: PropTypes.object.isRequired,
+  name: PropTypes.string.isRequired,
+  label: PropTypes.node,
+  helperText: PropTypes.node,
+  rules: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
+  description: PropTypes.node
+};
+
+export default Switch;
+

--- a/frontend/src/components/forms/Textarea.jsx
+++ b/frontend/src/components/forms/Textarea.jsx
@@ -1,0 +1,65 @@
+import PropTypes from 'prop-types';
+import { Controller } from 'react-hook-form';
+import { Label, Textarea as FlowbiteTextarea, HelperText } from 'flowbite-react';
+import { ExclamationCircleIcon } from '@heroicons/react/24/outline';
+
+function Textarea({ control, name, label, helperText, rules, description, rows = 4, ...rest }) {
+  const fieldId = rest.id ?? name;
+  const helperId = helperText ? `${fieldId}-helper` : undefined;
+
+  return (
+    <Controller
+      name={name}
+      control={control}
+      rules={rules}
+      render={({ field, fieldState }) => (
+        <div className="flex flex-col gap-1.5">
+          {label ? (
+            <Label htmlFor={fieldId} className="text-sm font-medium text-slate-700 dark:text-slate-200">
+              {label}
+            </Label>
+          ) : null}
+          {description ? (
+            <p id={`${fieldId}-description`} className="text-xs text-slate-500 dark:text-slate-400">
+              {description}
+            </p>
+          ) : null}
+          <FlowbiteTextarea
+            {...rest}
+            {...field}
+            id={fieldId}
+            rows={rows}
+            color={fieldState.invalid ? 'failure' : undefined}
+            aria-invalid={fieldState.invalid}
+            aria-describedby={[helperId, description ? `${fieldId}-description` : null]
+              .filter(Boolean)
+              .join(' ')}
+          />
+          {fieldState.error ? (
+            <HelperText id={helperId} color="failure" className="flex items-center gap-2 text-xs">
+              <ExclamationCircleIcon className="h-4 w-4" aria-hidden="true" />
+              <span>{fieldState.error.message}</span>
+            </HelperText>
+          ) : helperText ? (
+            <HelperText id={helperId} className="text-xs text-slate-500 dark:text-slate-400">
+              {helperText}
+            </HelperText>
+          ) : null}
+        </div>
+      )}
+    />
+  );
+}
+
+Textarea.propTypes = {
+  control: PropTypes.object.isRequired,
+  name: PropTypes.string.isRequired,
+  label: PropTypes.node,
+  helperText: PropTypes.node,
+  rules: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
+  description: PropTypes.node,
+  rows: PropTypes.number
+};
+
+export default Textarea;
+

--- a/frontend/src/pages/dashboard/CategoriesList.jsx
+++ b/frontend/src/pages/dashboard/CategoriesList.jsx
@@ -1,0 +1,180 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Button, Modal, TextInput } from 'flowbite-react';
+import { Link } from 'react-router-dom';
+import { PencilSquareIcon, PlusCircleIcon, TrashIcon, MagnifyingGlassIcon } from '@heroicons/react/24/outline';
+import DashboardLayout from './DashboardLayout.jsx';
+import DataTable from '../../components/DataTable.jsx';
+import { listarCategorias, eliminarCategoria } from '../../services/categories.js';
+import toast from 'react-hot-toast';
+
+const normalizeCollection = (payload) => {
+  if (Array.isArray(payload)) return payload;
+  if (payload?.results) return payload.results;
+  if (payload?.data) return payload.data;
+  return [];
+};
+
+function CategoriesList() {
+  const [categories, setCategories] = useState([]);
+  const [filteredCategories, setFilteredCategories] = useState([]);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [isLoading, setIsLoading] = useState(true);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [categoryToDelete, setCategoryToDelete] = useState(null);
+
+  const loadCategories = async () => {
+    setIsLoading(true);
+    try {
+      const response = await listarCategorias();
+      const items = normalizeCollection(response);
+      setCategories(items);
+      setFilteredCategories(items);
+    } catch (error) {
+      toast.error('No se pudieron cargar las categorías.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadCategories();
+  }, []);
+
+  useEffect(() => {
+    if (!searchTerm) {
+      setFilteredCategories(categories);
+      return;
+    }
+    const lower = searchTerm.toLowerCase();
+    setFilteredCategories(
+      categories.filter((category) =>
+        [category.name, category.slug]
+          .filter(Boolean)
+          .some((value) => String(value).toLowerCase().includes(lower))
+      )
+    );
+  }, [categories, searchTerm]);
+
+  const columns = useMemo(
+    () => [
+      {
+        accessorKey: 'name',
+        header: 'Nombre',
+        cell: ({ row }) => (
+          <span className="text-sm font-medium text-slate-700 dark:text-slate-200">
+            {row.original.name ?? 'Sin nombre'}
+          </span>
+        )
+      },
+      {
+        accessorKey: 'slug',
+        header: 'Slug',
+        cell: ({ row }) => (
+          <span className="text-sm text-slate-500 dark:text-slate-400">{row.original.slug ?? '-'}</span>
+        )
+      },
+      {
+        id: 'actions',
+        header: 'Acciones',
+        cell: ({ row }) => (
+          <div className="flex items-center gap-2">
+            <Button
+              as={Link}
+              to={`/dashboard/categories/${row.original.id ?? row.original.slug}/edit`}
+              color="light"
+              size="sm"
+              className="flex items-center gap-2"
+            >
+              <PencilSquareIcon className="h-4 w-4" aria-hidden="true" />
+              <span className="hidden sm:inline">Editar</span>
+            </Button>
+            <Button
+              color="failure"
+              size="sm"
+              className="flex items-center gap-2"
+              onClick={() => {
+                setCategoryToDelete(row.original);
+                setIsDeleting(true);
+              }}
+            >
+              <TrashIcon className="h-4 w-4" aria-hidden="true" />
+              <span className="hidden sm:inline">Eliminar</span>
+            </Button>
+          </div>
+        )
+      }
+    ],
+    []
+  );
+
+  const handleDelete = async () => {
+    if (!categoryToDelete) return;
+    try {
+      await eliminarCategoria(categoryToDelete.id ?? categoryToDelete.slug);
+      toast.success('Categoría eliminada correctamente.');
+      setIsDeleting(false);
+      setCategoryToDelete(null);
+      loadCategories();
+    } catch (error) {
+      toast.error('No se pudo eliminar la categoría.');
+    }
+  };
+
+  const toolbar = (
+    <div className="flex w-full flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+      <TextInput
+        value={searchTerm}
+        onChange={(event) => setSearchTerm(event.target.value)}
+        placeholder="Buscar categoría"
+        icon={MagnifyingGlassIcon}
+        aria-label="Buscar categoría"
+        className="w-full sm:max-w-xs"
+      />
+      <Button as={Link} to="/dashboard/categories/new" color="info" className="flex items-center gap-2">
+        <PlusCircleIcon className="h-5 w-5" aria-hidden="true" />
+        Nueva categoría
+      </Button>
+    </div>
+  );
+
+  return (
+    <DashboardLayout
+      title="Categorías"
+      description="Crea, edita o elimina las categorías disponibles para los posts."
+    >
+      <DataTable
+        columns={columns}
+        data={filteredCategories}
+        toolbar={toolbar}
+        isLoading={isLoading}
+        emptyMessage={isLoading ? ' ' : 'No hay categorías registradas.'}
+      />
+
+      <Modal show={isDeleting} size="md" popup onClose={() => setIsDeleting(false)}>
+        <Modal.Header />
+        <Modal.Body>
+          <div className="text-center">
+            <TrashIcon className="mx-auto mb-4 h-12 w-12 text-red-500" aria-hidden="true" />
+            <h3 className="mb-5 text-lg font-semibold text-slate-800 dark:text-slate-100">
+              ¿Eliminar esta categoría?
+            </h3>
+            <p className="mb-6 text-sm text-slate-500 dark:text-slate-400">
+              Los posts asociados deberán reasignarse manualmente si el backend lo requiere.
+            </p>
+            <div className="flex justify-center gap-4">
+              <Button color="gray" onClick={() => setIsDeleting(false)}>
+                Cancelar
+              </Button>
+              <Button color="failure" onClick={handleDelete}>
+                Eliminar
+              </Button>
+            </div>
+          </div>
+        </Modal.Body>
+      </Modal>
+    </DashboardLayout>
+  );
+}
+
+export default CategoriesList;
+

--- a/frontend/src/pages/dashboard/CategoryForm.jsx
+++ b/frontend/src/pages/dashboard/CategoryForm.jsx
@@ -1,0 +1,167 @@
+import { useEffect, useRef, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Button, Card, Spinner } from 'flowbite-react';
+import { ArrowLeftIcon, CheckCircleIcon } from '@heroicons/react/24/outline';
+import slugify from 'slugify';
+import DashboardLayout from './DashboardLayout.jsx';
+import Input from '../../components/forms/Input.jsx';
+import { crearCategoria, obtenerCategoria, actualizarCategoria } from '../../services/categories.js';
+import toast from 'react-hot-toast';
+
+const categorySchema = z.object({
+  name: z.string().trim().min(2, 'El nombre debe tener al menos 2 caracteres.'),
+  slug: z.string().trim().min(2, 'El slug debe tener al menos 2 caracteres.')
+});
+
+function CategoryForm() {
+  const navigate = useNavigate();
+  const { id } = useParams();
+  const isEditMode = Boolean(id);
+  const autoSlugRef = useRef('');
+
+  const {
+    control,
+    handleSubmit,
+    setValue,
+    setError,
+    reset,
+    watch,
+    formState: { isSubmitting }
+  } = useForm({
+    resolver: zodResolver(categorySchema),
+    defaultValues: {
+      name: '',
+      slug: ''
+    }
+  });
+
+  const [isLoading, setIsLoading] = useState(true);
+
+  const nameValue = watch('name');
+  const slugValue = watch('slug');
+
+  useEffect(() => {
+    const newSlug = slugify(nameValue ?? '', { lower: true, strict: true });
+    const shouldUpdateSlug = !slugValue || slugValue === autoSlugRef.current;
+    autoSlugRef.current = newSlug;
+    if (shouldUpdateSlug) {
+      setValue('slug', newSlug, { shouldDirty: false, shouldValidate: false });
+    }
+  }, [nameValue, slugValue, setValue]);
+
+  useEffect(() => {
+    const loadCategory = async () => {
+      if (!isEditMode) {
+        setIsLoading(false);
+        return;
+      }
+
+      try {
+        const category = await obtenerCategoria(id);
+        reset({
+          name: category.name ?? '',
+          slug: category.slug ?? ''
+        });
+      } catch (error) {
+        toast.error('No se pudo cargar la categoría solicitada.');
+        navigate('/dashboard/categories');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    loadCategory();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id]);
+
+  const onSubmit = async (values) => {
+    try {
+      if (isEditMode) {
+        await actualizarCategoria(id, values);
+        toast.success('Categoría actualizada correctamente.');
+      } else {
+        await crearCategoria(values);
+        toast.success('Categoría creada correctamente.');
+      }
+      navigate('/dashboard/categories');
+    } catch (error) {
+      const data = error.response?.data;
+      if (data && typeof data === 'object') {
+        let handled = false;
+        Object.entries(data).forEach(([field, messages]) => {
+          if (Array.isArray(messages) && messages.length > 0) {
+            handled = true;
+            setError(field, { type: 'server', message: messages[0] });
+          }
+        });
+        if (!handled) {
+          toast.error('Revisa los campos y vuelve a intentarlo.');
+        }
+      } else {
+        toast.error('No se pudo guardar la categoría.');
+      }
+    }
+  };
+
+  return (
+    <DashboardLayout
+      title={isEditMode ? 'Editar categoría' : 'Nueva categoría'}
+      description={
+        isEditMode
+          ? 'Actualiza el nombre y slug de la categoría seleccionada.'
+          : 'Crea una nueva categoría para organizar tus publicaciones.'
+      }
+      actions={
+        <Button as={Link} to="/dashboard/categories" color="light" className="flex items-center gap-2">
+          <ArrowLeftIcon className="h-5 w-5" aria-hidden="true" />
+          Volver al listado
+        </Button>
+      }
+    >
+      {isLoading ? (
+        <div className="flex min-h-[40vh] items-center justify-center">
+          <Spinner aria-label="Cargando categoría" size="xl" />
+        </div>
+      ) : (
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+          <Card className="space-y-6 border border-slate-200 bg-white/90 shadow-sm dark:border-slate-800 dark:bg-slate-900/80">
+            <Input
+              control={control}
+              name="name"
+              label="Nombre"
+              placeholder="Nombre de la categoría"
+            />
+            <Input
+              control={control}
+              name="slug"
+              label="Slug"
+              placeholder="slug-de-la-categoria"
+              helperText="Se utiliza en la URL para filtrar por categoría."
+            />
+            <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
+              <Button color="light" type="button" as={Link} to="/dashboard/categories">
+                Cancelar
+              </Button>
+              <Button
+                type="submit"
+                color="info"
+                className="flex items-center gap-2"
+                isProcessing={isSubmitting}
+                disabled={isSubmitting}
+              >
+                <CheckCircleIcon className="h-5 w-5" aria-hidden="true" />
+                {isEditMode ? 'Guardar cambios' : 'Crear categoría'}
+              </Button>
+            </div>
+          </Card>
+        </form>
+      )}
+    </DashboardLayout>
+  );
+}
+
+export default CategoryForm;
+

--- a/frontend/src/pages/dashboard/Dashboard.jsx
+++ b/frontend/src/pages/dashboard/Dashboard.jsx
@@ -1,0 +1,112 @@
+import { useEffect, useState } from 'react';
+import { Card, Spinner } from 'flowbite-react';
+import { NewspaperIcon, Squares2X2Icon, TagIcon } from '@heroicons/react/24/outline';
+import DashboardLayout from './DashboardLayout.jsx';
+import { listarPosts } from '../../services/posts.js';
+import { listarCategorias } from '../../services/categories.js';
+import { listarTags } from '../../services/tags.js';
+import toast from 'react-hot-toast';
+
+const metrics = [
+  {
+    key: 'posts',
+    title: 'Posts publicados',
+    description: 'Total de entradas registradas en el blog.',
+    icon: NewspaperIcon
+  },
+  {
+    key: 'categories',
+    title: 'Categorías activas',
+    description: 'Agrupaciones disponibles para organizar posts.',
+    icon: Squares2X2Icon
+  },
+  {
+    key: 'tags',
+    title: 'Tags disponibles',
+    description: 'Etiquetas para clasificar y filtrar contenido.',
+    icon: TagIcon
+  }
+];
+
+const extractCount = (payload) => {
+  if (payload == null) return 0;
+  if (typeof payload === 'number') return payload;
+  if (Array.isArray(payload)) return payload.length;
+  if (typeof payload === 'object') {
+    if (typeof payload.count === 'number') return payload.count;
+    if (Array.isArray(payload.results)) return payload.results.length;
+    if (Array.isArray(payload.data)) return payload.data.length;
+  }
+  return 0;
+};
+
+function Dashboard() {
+  const [isLoading, setIsLoading] = useState(true);
+  const [stats, setStats] = useState({ posts: 0, categories: 0, tags: 0 });
+
+  useEffect(() => {
+    const fetchStats = async () => {
+      setIsLoading(true);
+      try {
+        const [postsResponse, categoriesResponse, tagsResponse] = await Promise.all([
+          listarPosts({ pageSize: 1 }),
+          listarCategorias(),
+          listarTags()
+        ]);
+
+        setStats({
+          posts: extractCount(postsResponse),
+          categories: extractCount(categoriesResponse),
+          tags: extractCount(tagsResponse)
+        });
+      } catch (error) {
+        toast.error('No se pudieron obtener las métricas del dashboard.');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchStats();
+  }, []);
+
+  return (
+    <DashboardLayout
+      title="Panel de control"
+      description="Consulta de un vistazo el estado del contenido del blog."
+    >
+      {isLoading ? (
+        <div className="flex min-h-[40vh] items-center justify-center">
+          <Spinner aria-label="Cargando métricas" size="xl" />
+        </div>
+      ) : (
+        <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+          {metrics.map((metric) => {
+            const Icon = metric.icon;
+            return (
+              <Card
+                key={metric.key}
+                className="border border-slate-200 bg-white/90 shadow-sm transition hover:-translate-y-1 hover:shadow-lg dark:border-slate-800 dark:bg-slate-900/80"
+              >
+                <div className="flex items-center gap-4">
+                  <div className="rounded-full bg-sky-100 p-3 text-sky-600 dark:bg-sky-900/40 dark:text-sky-300">
+                    <Icon className="h-8 w-8" aria-hidden="true" />
+                  </div>
+                  <div>
+                    <p className="text-sm font-medium text-slate-500 dark:text-slate-400">{metric.title}</p>
+                    <p className="text-3xl font-semibold text-slate-900 dark:text-white">
+                      {stats[metric.key] ?? 0}
+                    </p>
+                  </div>
+                </div>
+                <p className="mt-4 text-sm text-slate-500 dark:text-slate-400">{metric.description}</p>
+              </Card>
+            );
+          })}
+        </div>
+      )}
+    </DashboardLayout>
+  );
+}
+
+export default Dashboard;
+

--- a/frontend/src/pages/dashboard/DashboardLayout.jsx
+++ b/frontend/src/pages/dashboard/DashboardLayout.jsx
@@ -1,0 +1,34 @@
+import PropTypes from 'prop-types';
+import Sidebar from '../../components/Sidebar.jsx';
+
+function DashboardLayout({ title, description, actions, children }) {
+  return (
+    <div className="flex flex-col gap-6 lg:flex-row">
+      <Sidebar />
+      <div className="flex-1">
+        <header className="mb-6 flex flex-col gap-4 rounded-xl border border-slate-200 bg-white/90 p-6 shadow-sm backdrop-blur dark:border-slate-800 dark:bg-slate-900/70">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <h1 className="text-2xl font-semibold text-slate-900 dark:text-white">{title}</h1>
+              {description ? (
+                <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">{description}</p>
+              ) : null}
+            </div>
+            {actions ? <div className="flex flex-wrap items-center gap-3">{actions}</div> : null}
+          </div>
+        </header>
+        <div className="space-y-6">{children}</div>
+      </div>
+    </div>
+  );
+}
+
+DashboardLayout.propTypes = {
+  title: PropTypes.string.isRequired,
+  description: PropTypes.node,
+  actions: PropTypes.node,
+  children: PropTypes.node.isRequired
+};
+
+export default DashboardLayout;
+

--- a/frontend/src/pages/dashboard/PostForm.jsx
+++ b/frontend/src/pages/dashboard/PostForm.jsx
@@ -1,0 +1,416 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Button, Card, Spinner } from 'flowbite-react';
+import { ArrowLeftIcon, CloudArrowUpIcon } from '@heroicons/react/24/outline';
+import slugify from 'slugify';
+import ReactQuill from 'react-quill';
+import 'react-quill/dist/quill.snow.css';
+import DashboardLayout from './DashboardLayout.jsx';
+import Input from '../../components/forms/Input.jsx';
+import Textarea from '../../components/forms/Textarea.jsx';
+import Select from '../../components/forms/Select.jsx';
+import MultiSelect from '../../components/forms/MultiSelect.jsx';
+import FileUpload from '../../components/forms/FileUpload.jsx';
+import Switch from '../../components/forms/Switch.jsx';
+import { listarCategorias } from '../../services/categories.js';
+import { listarTags } from '../../services/tags.js';
+import { actualizarPost, crearPost, obtenerPost } from '../../services/posts.js';
+import toast from 'react-hot-toast';
+
+const normalizeCollection = (payload) => {
+  if (Array.isArray(payload)) return payload;
+  if (payload?.results) return payload.results;
+  if (payload?.data) return payload.data;
+  return [];
+};
+
+const tagOptionSchema = z.object({
+  value: z.union([z.string(), z.number()]),
+  label: z.string()
+});
+
+const postSchema = z
+  .object({
+    title: z.string().trim().min(3, 'El título debe tener al menos 3 caracteres.'),
+    slug: z.string().trim().min(3, 'El slug debe tener al menos 3 caracteres.'),
+    excerpt: z.string().optional(),
+    content: z.string(),
+    category: z.string().min(1, 'Selecciona una categoría.'),
+    tags: z.array(tagOptionSchema).optional(),
+    image: z.any().nullable().optional(),
+    published: z.boolean().default(false)
+  })
+  .superRefine((value, ctx) => {
+    const plain = value.content
+      ?.replace(/<[^>]*>/g, ' ')
+      .replace(/&nbsp;/g, ' ')
+      .trim();
+    if (!plain || plain.length < 20) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['content'],
+        message: 'El contenido debe tener al menos 20 caracteres.'
+      });
+    }
+  });
+
+const quillModules = {
+  toolbar: [
+    [{ header: [1, 2, 3, false] }],
+    ['bold', 'italic', 'underline', 'strike'],
+    [{ list: 'ordered' }, { list: 'bullet' }],
+    ['link', 'blockquote', 'code-block'],
+    ['clean']
+  ]
+};
+
+function PostForm() {
+  const navigate = useNavigate();
+  const { id } = useParams();
+  const isEditMode = Boolean(id);
+
+  const {
+    control,
+    handleSubmit,
+    reset,
+    watch,
+    setValue,
+    setError,
+    formState: { isSubmitting, errors }
+  } = useForm({
+    resolver: zodResolver(postSchema),
+    defaultValues: {
+      title: '',
+      slug: '',
+      excerpt: '',
+      content: '',
+      category: '',
+      tags: [],
+      image: null,
+      published: false
+    }
+  });
+
+  const [categoryOptions, setCategoryOptions] = useState([]);
+  const [tagOptions, setTagOptions] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [existingImage, setExistingImage] = useState(null);
+  const [contentError, setContentError] = useState(null);
+  const [previewUrl, setPreviewUrl] = useState(null);
+
+  const titleValue = watch('title');
+  const slugValue = watch('slug');
+  const contentValue = watch('content');
+  const imageValue = watch('image');
+  const autoSlugRef = useRef('');
+
+  const validationContentError = errors?.content?.message;
+
+  useEffect(() => {
+    const newSlug = slugify(titleValue ?? '', { lower: true, strict: true });
+    const shouldUpdateSlug = !slugValue || slugValue === autoSlugRef.current;
+    autoSlugRef.current = newSlug;
+    if (shouldUpdateSlug) {
+      setValue('slug', newSlug, { shouldDirty: false, shouldValidate: false });
+    }
+  }, [titleValue, slugValue, setValue]);
+
+  useEffect(() => {
+    if (imageValue instanceof File) {
+      const objectUrl = URL.createObjectURL(imageValue);
+      setPreviewUrl(objectUrl);
+      return () => URL.revokeObjectURL(objectUrl);
+    }
+    if (!imageValue) {
+      setPreviewUrl(existingImage ?? null);
+    }
+    return undefined;
+  }, [imageValue, existingImage]);
+
+  const fetchTaxonomies = async () => {
+    try {
+      const [categoriesResponse, tagsResponse] = await Promise.all([
+        listarCategorias(),
+        listarTags()
+      ]);
+
+      setCategoryOptions(
+        normalizeCollection(categoriesResponse).map((category) => ({
+          value: category.slug ?? category.id,
+          label: category.name ?? category.title ?? 'Sin nombre'
+        }))
+      );
+
+      setTagOptions(
+        normalizeCollection(tagsResponse).map((tag) => ({
+          value: tag.id ?? tag.slug,
+          label: tag.name ?? tag.title ?? 'Sin nombre'
+        }))
+      );
+    } catch (error) {
+      toast.error('No fue posible cargar categorías y tags.');
+    }
+  };
+
+  const fetchPost = async () => {
+    if (!isEditMode) {
+      return;
+    }
+
+    try {
+      const post = await obtenerPost(id);
+      const tagsData = post.tags_detail ?? post.tags ?? [];
+      const categoryValue =
+        post.category ??
+        post.category_slug ??
+        post.category_detail?.slug ??
+        post.category_detail?.id ??
+        '';
+
+      reset({
+        title: post.title ?? '',
+        slug: post.slug ?? '',
+        excerpt: post.excerpt ?? '',
+        content: post.content ?? '',
+        category: categoryValue,
+        tags: tagsData.map((tag) => ({
+          value: tag.id ?? tag.slug,
+          label: tag.name ?? tag.title ?? tag
+        })),
+        image: null,
+        published: Boolean(post.published)
+      });
+
+      if (post.image || post.featured_image) {
+        setExistingImage(post.image ?? post.featured_image);
+        setPreviewUrl(post.image ?? post.featured_image);
+      }
+    } catch (error) {
+      toast.error('No se pudo cargar el post solicitado.');
+      navigate('/dashboard/posts');
+    }
+  };
+
+  useEffect(() => {
+    const loadData = async () => {
+      setIsLoading(true);
+      await fetchTaxonomies();
+      await fetchPost();
+      setIsLoading(false);
+    };
+
+    loadData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id]);
+
+  useEffect(() => {
+    const plain = contentValue?.replace(/<[^>]*>/g, ' ').replace(/&nbsp;/g, ' ').trim();
+    if (plain && plain.length >= 20) {
+      setContentError(null);
+    }
+  }, [contentValue]);
+
+  const displayedContentError = validationContentError ?? contentError;
+
+  const onSubmit = async (values) => {
+    const formData = new FormData();
+    formData.append('title', values.title.trim());
+    formData.append('slug', values.slug.trim());
+    formData.append('excerpt', values.excerpt ?? '');
+    formData.append('content', values.content);
+    formData.append('category', values.category);
+    (values.tags ?? []).forEach((tag) => {
+      formData.append('tags[]', tag.value);
+    });
+    formData.append('published', values.published ? 'true' : 'false');
+
+    if (values.image instanceof File) {
+      formData.append('image', values.image);
+    }
+
+    try {
+      if (isEditMode) {
+        await actualizarPost(id, formData);
+        toast.success('Post actualizado correctamente.');
+      } else {
+        await crearPost(formData);
+        toast.success('Post creado correctamente.');
+      }
+      navigate('/dashboard/posts');
+    } catch (error) {
+      const data = error.response?.data;
+      if (data && typeof data === 'object') {
+        let handled = false;
+        Object.entries(data).forEach(([field, messages]) => {
+          if (Array.isArray(messages) && messages.length > 0) {
+            handled = true;
+            if (field === 'content') {
+              setContentError(messages[0]);
+            } else {
+              setError(field, { type: 'server', message: messages[0] });
+            }
+          }
+        });
+        if (!handled) {
+          toast.error('Revisa los datos del formulario e inténtalo nuevamente.');
+        }
+      } else {
+        toast.error('No se pudo guardar el post. Intenta de nuevo más tarde.');
+      }
+    }
+  };
+
+  const tagSelectOptions = useMemo(() => tagOptions, [tagOptions]);
+
+  return (
+    <DashboardLayout
+      title={isEditMode ? 'Editar post' : 'Nuevo post'}
+      description={
+        isEditMode
+          ? 'Actualiza los datos del post y controla su publicación.'
+          : 'Completa los campos para crear una nueva publicación.'
+      }
+      actions={
+        <Button as={Link} to="/dashboard/posts" color="light" className="flex items-center gap-2">
+          <ArrowLeftIcon className="h-5 w-5" aria-hidden="true" />
+          Volver al listado
+        </Button>
+      }
+    >
+      {isLoading ? (
+        <div className="flex min-h-[40vh] items-center justify-center">
+          <Spinner aria-label="Cargando post" size="xl" />
+        </div>
+      ) : (
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+          <Card className="space-y-6 border border-slate-200 bg-white/90 shadow-sm dark:border-slate-800 dark:bg-slate-900/80">
+            <div className="grid gap-6 lg:grid-cols-2">
+              <Input
+                control={control}
+                name="title"
+                label="Título"
+                placeholder="Ingresa el título del post"
+              />
+              <Input
+                control={control}
+                name="slug"
+                label="Slug"
+                placeholder="auto-generado"
+                helperText="Este valor se utilizará en la URL pública."
+              />
+            </div>
+            <Textarea
+              control={control}
+              name="excerpt"
+              label="Resumen"
+              rows={4}
+              placeholder="Introduce un resumen breve del post"
+            />
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-slate-700 dark:text-slate-200" htmlFor="post-content">
+                Contenido
+              </label>
+              <ReactQuill
+                id="post-content"
+                theme="snow"
+                value={contentValue}
+                onChange={(value) => setValue('content', value, { shouldDirty: true })}
+                modules={quillModules}
+                aria-label="Contenido del post"
+              />
+              {displayedContentError ? (
+                <p className="text-xs text-red-500">{displayedContentError}</p>
+              ) : (
+                <p className="text-xs text-slate-500 dark:text-slate-400">
+                  Utiliza el editor para dar formato al contenido del post.
+                </p>
+              )}
+            </div>
+            <div className="grid gap-6 lg:grid-cols-2">
+              <Select
+                control={control}
+                name="category"
+                label="Categoría"
+                placeholder="Selecciona una categoría"
+              >
+                <option value="" disabled>
+                  Selecciona una categoría
+                </option>
+                {categoryOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </Select>
+              <MultiSelect
+                control={control}
+                name="tags"
+                label="Tags"
+                options={tagSelectOptions}
+                placeholder="Selecciona tags relacionados"
+                helperText="Puedes elegir varias etiquetas para mejorar el filtrado."
+              />
+            </div>
+            <div className="grid gap-6 lg:grid-cols-2">
+              <FileUpload
+                control={control}
+                name="image"
+                label="Imagen destacada"
+                helperText="Formatos aceptados: JPG, PNG o WebP. Máximo 5MB."
+                accept="image/*"
+                onClear={() => {
+                  setExistingImage(null);
+                  setPreviewUrl(null);
+                }}
+              />
+              <div className="flex flex-col gap-3">
+                <Switch
+                  control={control}
+                  name="published"
+                  label="Publicar inmediatamente"
+                  helperText="Si está activado, el post será visible para la audiencia."
+                />
+                {previewUrl ? (
+                  <div className="overflow-hidden rounded-lg border border-slate-200 bg-slate-50 dark:border-slate-800 dark:bg-slate-900/60">
+                    <img src={previewUrl} alt="Vista previa de la imagen" className="h-40 w-full object-cover" />
+                  </div>
+                ) : (
+                  <div className="flex h-40 items-center justify-center rounded-lg border border-dashed border-slate-300 bg-white text-sm text-slate-400 dark:border-slate-700 dark:bg-slate-900/40 dark:text-slate-500">
+                    La vista previa de la imagen aparecerá aquí.
+                  </div>
+                )}
+              </div>
+            </div>
+            <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
+              <Button
+                color="light"
+                type="button"
+                as={Link}
+                to="/dashboard/posts"
+                className="flex items-center gap-2"
+              >
+                Cancelar
+              </Button>
+              <Button
+                type="submit"
+                color="info"
+                className="flex items-center gap-2"
+                isProcessing={isSubmitting}
+                disabled={isSubmitting}
+              >
+                <CloudArrowUpIcon className="h-5 w-5" aria-hidden="true" />
+                {isEditMode ? 'Guardar cambios' : 'Crear post'}
+              </Button>
+            </div>
+          </Card>
+        </form>
+      )}
+    </DashboardLayout>
+  );
+}
+
+export default PostForm;
+

--- a/frontend/src/pages/dashboard/PostsList.jsx
+++ b/frontend/src/pages/dashboard/PostsList.jsx
@@ -1,0 +1,401 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Button, Badge, Modal, TextInput, ToggleSwitch } from 'flowbite-react';
+import { Link } from 'react-router-dom';
+import {
+  PencilSquareIcon,
+  TrashIcon,
+  PlusCircleIcon,
+  MagnifyingGlassIcon
+} from '@heroicons/react/24/outline';
+import Select from 'react-select';
+import DashboardLayout from './DashboardLayout.jsx';
+import DataTable from '../../components/DataTable.jsx';
+import { listarPosts, eliminarPost } from '../../services/posts.js';
+import { listarCategorias } from '../../services/categories.js';
+import { listarTags } from '../../services/tags.js';
+import toast from 'react-hot-toast';
+import { useUIStore, selectIsDark } from '../../store/useUI';
+
+const PAGE_SIZE = 10;
+
+const createFilterSelectStyles = (isDarkMode) => ({
+  control: (provided, state) => ({
+    ...provided,
+    backgroundColor: isDarkMode ? 'rgba(15,23,42,0.7)' : 'transparent',
+    borderColor: state.isFocused
+      ? 'rgb(14 165 233 / 0.8)'
+      : isDarkMode
+        ? 'rgba(71, 85, 105, 0.8)'
+        : 'rgb(226 232 240)',
+    boxShadow: state.isFocused ? '0 0 0 2px rgb(14 165 233 / 0.25)' : 'none',
+    color: isDarkMode ? 'rgb(226 232 240)' : 'rgb(15 23 42)'
+  }),
+  menu: (provided) => ({
+    ...provided,
+    backgroundColor: isDarkMode ? 'rgba(15,23,42,0.95)' : 'white',
+    zIndex: 40
+  }),
+  option: (provided, state) => ({
+    ...provided,
+    backgroundColor: state.isSelected
+      ? 'rgb(14 165 233 / 0.25)'
+      : state.isFocused
+        ? 'rgb(14 165 233 / 0.15)'
+        : isDarkMode
+          ? 'rgba(15,23,42,0.95)'
+          : 'transparent',
+    color: isDarkMode ? 'rgb(226 232 240)' : 'rgb(15 23 42)'
+  }),
+  placeholder: (provided) => ({
+    ...provided,
+    color: isDarkMode ? 'rgb(148 163 184)' : 'rgb(100 116 139)'
+  }),
+  multiValue: (provided) => ({
+    ...provided,
+    backgroundColor: isDarkMode ? 'rgba(56,189,248,0.25)' : 'rgb(14 165 233 / 0.15)' 
+  }),
+  multiValueLabel: (provided) => ({
+    ...provided,
+    color: isDarkMode ? 'rgb(191 219 254)' : provided.color
+  })
+});
+
+const normalizeCollection = (payload) => {
+  if (Array.isArray(payload)) {
+    return payload;
+  }
+  if (payload?.results) {
+    return payload.results;
+  }
+  if (payload?.data) {
+    return payload.data;
+  }
+  return [];
+};
+
+const extractCount = (payload, fallbackLength) => {
+  if (typeof payload?.count === 'number') {
+    return payload.count;
+  }
+  return fallbackLength;
+};
+
+const formatDate = (value) => {
+  if (!value) return 'Sin fecha';
+  try {
+    return new Date(value).toLocaleDateString('es-ES', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric'
+    });
+  } catch (error) {
+    return value;
+  }
+};
+
+function PostsList() {
+  const isDarkMode = useUIStore(selectIsDark);
+  const tagFilterStyles = useMemo(() => createFilterSelectStyles(isDarkMode), [isDarkMode]);
+  const [posts, setPosts] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [categoryOptions, setCategoryOptions] = useState([]);
+  const [tagOptions, setTagOptions] = useState([]);
+  const [selectedTags, setSelectedTags] = useState([]);
+  const [selectedCategory, setSelectedCategory] = useState('');
+  const [searchTerm, setSearchTerm] = useState('');
+  const [onlyPublished, setOnlyPublished] = useState(false);
+  const [currentPage, setCurrentPage] = useState(0);
+  const [totalItems, setTotalItems] = useState(0);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [postToDelete, setPostToDelete] = useState(null);
+
+  const fetchTaxonomies = useCallback(async () => {
+    try {
+      const [categoriesResponse, tagsResponse] = await Promise.all([
+        listarCategorias(),
+        listarTags()
+      ]);
+
+      setCategoryOptions(
+        normalizeCollection(categoriesResponse).map((category) => ({
+          value: category.slug ?? category.id,
+          label: category.name ?? category.title ?? 'Sin nombre'
+        }))
+      );
+
+      setTagOptions(
+        normalizeCollection(tagsResponse).map((tag) => ({
+          value: tag.id ?? tag.slug,
+          label: tag.name ?? tag.title ?? 'Sin nombre'
+        }))
+      );
+    } catch (error) {
+      toast.error('No se pudieron cargar categorías y tags.');
+    }
+  }, []);
+
+  const loadPosts = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const response = await listarPosts({
+        page: currentPage + 1,
+        pageSize: PAGE_SIZE,
+        search: searchTerm || undefined,
+        category: selectedCategory || undefined,
+        tags: selectedTags.map((tag) => tag.value),
+        published: onlyPublished ? true : undefined,
+        ordering: '-created_at'
+      });
+
+      const items = normalizeCollection(response);
+      setPosts(items);
+      const total = extractCount(response, items.length);
+      setTotalItems(total);
+      const pageCount = Math.max(1, Math.ceil(total / PAGE_SIZE));
+      if (currentPage >= pageCount) {
+        setCurrentPage(pageCount - 1);
+      }
+    } catch (error) {
+      toast.error('No fue posible obtener la lista de posts.');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [currentPage, onlyPublished, searchTerm, selectedCategory, selectedTags]);
+
+  useEffect(() => {
+    fetchTaxonomies();
+  }, [fetchTaxonomies]);
+
+  useEffect(() => {
+    loadPosts();
+  }, [loadPosts]);
+
+  const columns = useMemo(
+    () => [
+      {
+        accessorKey: 'title',
+        header: 'Título',
+        cell: ({ row }) => (
+          <div className="flex flex-col">
+            <span className="font-semibold text-slate-800 dark:text-slate-200">{row.original.title}</span>
+            <span className="text-xs text-slate-500 dark:text-slate-400">{row.original.slug}</span>
+          </div>
+        )
+      },
+      {
+        accessorKey: 'category',
+        header: 'Categoría',
+        cell: ({ row }) => {
+          const category = row.original.category_detail ?? row.original.category ?? row.original.category_name;
+          if (!category) {
+            return <span className="text-sm text-slate-400">Sin categoría</span>;
+          }
+          const name = typeof category === 'string' ? category : category.name ?? category.title ?? 'Sin categoría';
+          return <span className="text-sm text-slate-600 dark:text-slate-300">{name}</span>;
+        }
+      },
+      {
+        accessorKey: 'tags',
+        header: 'Tags',
+        cell: ({ row }) => {
+          const tags = row.original.tags_detail ?? row.original.tags ?? [];
+          if (!tags || tags.length === 0) {
+            return <span className="text-sm text-slate-400">Sin tags</span>;
+          }
+          return (
+            <div className="flex flex-wrap gap-1">
+              {tags.map((tag) => {
+                const label = tag.name ?? tag.title ?? tag;
+                return (
+                  <Badge key={tag.id ?? tag.slug ?? label} color="info">
+                    {label}
+                  </Badge>
+                );
+              })}
+            </div>
+          );
+        }
+      },
+      {
+        accessorKey: 'published',
+        header: 'Publicado',
+        cell: ({ row }) => (
+          <Badge color={row.original.published ? 'success' : 'gray'}>
+            {row.original.published ? 'Publicado' : 'Borrador'}
+          </Badge>
+        )
+      },
+      {
+        accessorKey: 'created_at',
+        header: 'Fecha',
+        cell: ({ row }) => (
+          <span className="text-sm text-slate-500 dark:text-slate-400">
+            {formatDate(row.original.created_at ?? row.original.created ?? row.original.published_at)}
+          </span>
+        )
+      },
+      {
+        id: 'actions',
+        header: 'Acciones',
+        cell: ({ row }) => (
+          <div className="flex items-center gap-2">
+            <Button
+              as={Link}
+              to={`/dashboard/posts/${row.original.id ?? row.original.slug}/edit`}
+              color="light"
+              size="sm"
+              className="flex items-center gap-2"
+            >
+              <PencilSquareIcon className="h-4 w-4" aria-hidden="true" />
+              <span className="hidden sm:inline">Editar</span>
+            </Button>
+            <Button
+              color="failure"
+              size="sm"
+              className="flex items-center gap-2"
+              onClick={() => {
+                setPostToDelete(row.original);
+                setIsDeleting(true);
+              }}
+            >
+              <TrashIcon className="h-4 w-4" aria-hidden="true" />
+              <span className="hidden sm:inline">Eliminar</span>
+            </Button>
+          </div>
+        )
+      }
+    ],
+    []
+  );
+
+  const pagination = useMemo(
+    () => ({
+      pageIndex: currentPage,
+      pageSize: PAGE_SIZE,
+      pageCount: Math.max(1, Math.ceil(totalItems / PAGE_SIZE)),
+      totalItems,
+      onPageChange: setCurrentPage,
+      mode: 'server'
+    }),
+    [currentPage, totalItems]
+  );
+
+  const handleDelete = async () => {
+    if (!postToDelete) return;
+    try {
+      await eliminarPost(postToDelete.id ?? postToDelete.slug);
+      toast.success('El post se eliminó correctamente.');
+      setIsDeleting(false);
+      setPostToDelete(null);
+      loadPosts();
+    } catch (error) {
+      toast.error('No se pudo eliminar el post, inténtalo nuevamente.');
+    }
+  };
+
+  const toolbar = (
+    <div className="flex w-full flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+      <div className="flex flex-1 flex-col gap-3 lg:flex-row lg:items-end">
+        <div className="flex flex-1 items-center gap-3">
+          <TextInput
+            value={searchTerm}
+            onChange={(event) => {
+              setSearchTerm(event.target.value);
+              setCurrentPage(0);
+            }}
+            placeholder="Buscar por título o resumen"
+            icon={MagnifyingGlassIcon}
+            aria-label="Buscar posts"
+            className="w-full"
+          />
+          <ToggleSwitch
+            label="Solo publicados"
+            checked={onlyPublished}
+            onChange={(value) => {
+              setOnlyPublished(value);
+              setCurrentPage(0);
+            }}
+          />
+        </div>
+        <div className="flex flex-1 flex-col gap-3 sm:flex-row">
+          <select
+            value={selectedCategory}
+            onChange={(event) => {
+              setSelectedCategory(event.target.value);
+              setCurrentPage(0);
+            }}
+            className="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-600 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200"
+          >
+            <option value="">Todas las categorías</option>
+            {categoryOptions.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+          <Select
+            isMulti
+            value={selectedTags}
+            onChange={(value) => {
+              setSelectedTags(value ?? []);
+              setCurrentPage(0);
+            }}
+            options={tagOptions}
+            placeholder="Filtrar por tags"
+            className="w-full"
+            classNamePrefix="posts-tag-filter"
+            styles={tagFilterStyles}
+            aria-label="Filtrar por tags"
+            isClearable
+          />
+        </div>
+      </div>
+      <Button as={Link} to="/dashboard/posts/new" color="info" className="flex items-center gap-2">
+        <PlusCircleIcon className="h-5 w-5" aria-hidden="true" />
+        Nuevo post
+      </Button>
+    </div>
+  );
+
+  return (
+    <DashboardLayout
+      title="Gestión de posts"
+      description="Administra las publicaciones existentes, crea nuevas y controla su estado."
+    >
+      <DataTable
+        columns={columns}
+        data={posts}
+        toolbar={toolbar}
+        pagination={pagination}
+        isLoading={isLoading}
+        emptyMessage={isLoading ? ' ' : 'No se encontraron posts con los filtros seleccionados.'}
+      />
+
+      <Modal show={isDeleting} size="md" popup onClose={() => setIsDeleting(false)}>
+        <Modal.Header />
+        <Modal.Body>
+          <div className="text-center">
+            <TrashIcon className="mx-auto mb-4 h-12 w-12 text-red-500" aria-hidden="true" />
+            <h3 className="mb-5 text-lg font-semibold text-slate-800 dark:text-slate-100">
+              ¿Deseas eliminar este post?
+            </h3>
+            <p className="mb-6 text-sm text-slate-500 dark:text-slate-400">
+              Esta acción no se puede deshacer y retirará la publicación del sitio.
+            </p>
+            <div className="flex justify-center gap-4">
+              <Button color="gray" onClick={() => setIsDeleting(false)}>
+                Cancelar
+              </Button>
+              <Button color="failure" onClick={handleDelete}>
+                Eliminar definitivamente
+              </Button>
+            </div>
+          </div>
+        </Modal.Body>
+      </Modal>
+    </DashboardLayout>
+  );
+}
+
+export default PostsList;
+

--- a/frontend/src/pages/dashboard/TagForm.jsx
+++ b/frontend/src/pages/dashboard/TagForm.jsx
@@ -1,0 +1,162 @@
+import { useEffect, useRef, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Button, Card, Spinner } from 'flowbite-react';
+import { ArrowLeftIcon, CheckCircleIcon } from '@heroicons/react/24/outline';
+import slugify from 'slugify';
+import DashboardLayout from './DashboardLayout.jsx';
+import Input from '../../components/forms/Input.jsx';
+import { crearTag, obtenerTag, actualizarTag } from '../../services/tags.js';
+import toast from 'react-hot-toast';
+
+const tagSchema = z.object({
+  name: z.string().trim().min(2, 'El nombre debe tener al menos 2 caracteres.'),
+  slug: z.string().trim().min(2, 'El slug debe tener al menos 2 caracteres.')
+});
+
+function TagForm() {
+  const navigate = useNavigate();
+  const { id } = useParams();
+  const isEditMode = Boolean(id);
+  const autoSlugRef = useRef('');
+
+  const {
+    control,
+    handleSubmit,
+    setValue,
+    setError,
+    reset,
+    watch,
+    formState: { isSubmitting }
+  } = useForm({
+    resolver: zodResolver(tagSchema),
+    defaultValues: {
+      name: '',
+      slug: ''
+    }
+  });
+
+  const [isLoading, setIsLoading] = useState(true);
+
+  const nameValue = watch('name');
+  const slugValue = watch('slug');
+
+  useEffect(() => {
+    const newSlug = slugify(nameValue ?? '', { lower: true, strict: true });
+    const shouldUpdateSlug = !slugValue || slugValue === autoSlugRef.current;
+    autoSlugRef.current = newSlug;
+    if (shouldUpdateSlug) {
+      setValue('slug', newSlug, { shouldDirty: false, shouldValidate: false });
+    }
+  }, [nameValue, slugValue, setValue]);
+
+  useEffect(() => {
+    const loadTag = async () => {
+      if (!isEditMode) {
+        setIsLoading(false);
+        return;
+      }
+
+      try {
+        const tag = await obtenerTag(id);
+        reset({
+          name: tag.name ?? '',
+          slug: tag.slug ?? ''
+        });
+      } catch (error) {
+        toast.error('No se pudo cargar el tag solicitado.');
+        navigate('/dashboard/tags');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    loadTag();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id]);
+
+  const onSubmit = async (values) => {
+    try {
+      if (isEditMode) {
+        await actualizarTag(id, values);
+        toast.success('Tag actualizado correctamente.');
+      } else {
+        await crearTag(values);
+        toast.success('Tag creado correctamente.');
+      }
+      navigate('/dashboard/tags');
+    } catch (error) {
+      const data = error.response?.data;
+      if (data && typeof data === 'object') {
+        let handled = false;
+        Object.entries(data).forEach(([field, messages]) => {
+          if (Array.isArray(messages) && messages.length > 0) {
+            handled = true;
+            setError(field, { type: 'server', message: messages[0] });
+          }
+        });
+        if (!handled) {
+          toast.error('Revisa los campos y vuelve a intentarlo.');
+        }
+      } else {
+        toast.error('No se pudo guardar el tag.');
+      }
+    }
+  };
+
+  return (
+    <DashboardLayout
+      title={isEditMode ? 'Editar tag' : 'Nuevo tag'}
+      description={
+        isEditMode
+          ? 'Ajusta el nombre y slug del tag seleccionado.'
+          : 'Crea un nuevo tag para etiquetar tus publicaciones.'
+      }
+      actions={
+        <Button as={Link} to="/dashboard/tags" color="light" className="flex items-center gap-2">
+          <ArrowLeftIcon className="h-5 w-5" aria-hidden="true" />
+          Volver al listado
+        </Button>
+      }
+    >
+      {isLoading ? (
+        <div className="flex min-h-[40vh] items-center justify-center">
+          <Spinner aria-label="Cargando tag" size="xl" />
+        </div>
+      ) : (
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+          <Card className="space-y-6 border border-slate-200 bg-white/90 shadow-sm dark:border-slate-800 dark:bg-slate-900/80">
+            <Input control={control} name="name" label="Nombre" placeholder="Nombre del tag" />
+            <Input
+              control={control}
+              name="slug"
+              label="Slug"
+              placeholder="slug-del-tag"
+              helperText="Se utiliza en la URL para filtrar por tag."
+            />
+            <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
+              <Button color="light" type="button" as={Link} to="/dashboard/tags">
+                Cancelar
+              </Button>
+              <Button
+                type="submit"
+                color="info"
+                className="flex items-center gap-2"
+                isProcessing={isSubmitting}
+                disabled={isSubmitting}
+              >
+                <CheckCircleIcon className="h-5 w-5" aria-hidden="true" />
+                {isEditMode ? 'Guardar cambios' : 'Crear tag'}
+              </Button>
+            </div>
+          </Card>
+        </form>
+      )}
+    </DashboardLayout>
+  );
+}
+
+export default TagForm;
+

--- a/frontend/src/pages/dashboard/TagsList.jsx
+++ b/frontend/src/pages/dashboard/TagsList.jsx
@@ -1,0 +1,180 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Button, Modal, TextInput } from 'flowbite-react';
+import { Link } from 'react-router-dom';
+import { PencilSquareIcon, PlusCircleIcon, TrashIcon, MagnifyingGlassIcon } from '@heroicons/react/24/outline';
+import DashboardLayout from './DashboardLayout.jsx';
+import DataTable from '../../components/DataTable.jsx';
+import { listarTags, eliminarTag } from '../../services/tags.js';
+import toast from 'react-hot-toast';
+
+const normalizeCollection = (payload) => {
+  if (Array.isArray(payload)) return payload;
+  if (payload?.results) return payload.results;
+  if (payload?.data) return payload.data;
+  return [];
+};
+
+function TagsList() {
+  const [tags, setTags] = useState([]);
+  const [filteredTags, setFilteredTags] = useState([]);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [isLoading, setIsLoading] = useState(true);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [tagToDelete, setTagToDelete] = useState(null);
+
+  const loadTags = async () => {
+    setIsLoading(true);
+    try {
+      const response = await listarTags();
+      const items = normalizeCollection(response);
+      setTags(items);
+      setFilteredTags(items);
+    } catch (error) {
+      toast.error('No se pudieron cargar los tags.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadTags();
+  }, []);
+
+  useEffect(() => {
+    if (!searchTerm) {
+      setFilteredTags(tags);
+      return;
+    }
+    const lower = searchTerm.toLowerCase();
+    setFilteredTags(
+      tags.filter((tag) =>
+        [tag.name, tag.slug]
+          .filter(Boolean)
+          .some((value) => String(value).toLowerCase().includes(lower))
+      )
+    );
+  }, [tags, searchTerm]);
+
+  const columns = useMemo(
+    () => [
+      {
+        accessorKey: 'name',
+        header: 'Nombre',
+        cell: ({ row }) => (
+          <span className="text-sm font-medium text-slate-700 dark:text-slate-200">
+            {row.original.name ?? 'Sin nombre'}
+          </span>
+        )
+      },
+      {
+        accessorKey: 'slug',
+        header: 'Slug',
+        cell: ({ row }) => (
+          <span className="text-sm text-slate-500 dark:text-slate-400">{row.original.slug ?? '-'}</span>
+        )
+      },
+      {
+        id: 'actions',
+        header: 'Acciones',
+        cell: ({ row }) => (
+          <div className="flex items-center gap-2">
+            <Button
+              as={Link}
+              to={`/dashboard/tags/${row.original.id ?? row.original.slug}/edit`}
+              color="light"
+              size="sm"
+              className="flex items-center gap-2"
+            >
+              <PencilSquareIcon className="h-4 w-4" aria-hidden="true" />
+              <span className="hidden sm:inline">Editar</span>
+            </Button>
+            <Button
+              color="failure"
+              size="sm"
+              className="flex items-center gap-2"
+              onClick={() => {
+                setTagToDelete(row.original);
+                setIsDeleting(true);
+              }}
+            >
+              <TrashIcon className="h-4 w-4" aria-hidden="true" />
+              <span className="hidden sm:inline">Eliminar</span>
+            </Button>
+          </div>
+        )
+      }
+    ],
+    []
+  );
+
+  const handleDelete = async () => {
+    if (!tagToDelete) return;
+    try {
+      await eliminarTag(tagToDelete.id ?? tagToDelete.slug);
+      toast.success('Tag eliminado correctamente.');
+      setIsDeleting(false);
+      setTagToDelete(null);
+      loadTags();
+    } catch (error) {
+      toast.error('No se pudo eliminar el tag.');
+    }
+  };
+
+  const toolbar = (
+    <div className="flex w-full flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+      <TextInput
+        value={searchTerm}
+        onChange={(event) => setSearchTerm(event.target.value)}
+        placeholder="Buscar tag"
+        icon={MagnifyingGlassIcon}
+        aria-label="Buscar tag"
+        className="w-full sm:max-w-xs"
+      />
+      <Button as={Link} to="/dashboard/tags/new" color="info" className="flex items-center gap-2">
+        <PlusCircleIcon className="h-5 w-5" aria-hidden="true" />
+        Nuevo tag
+      </Button>
+    </div>
+  );
+
+  return (
+    <DashboardLayout
+      title="Tags"
+      description="Administra las etiquetas disponibles para los posts."
+    >
+      <DataTable
+        columns={columns}
+        data={filteredTags}
+        toolbar={toolbar}
+        isLoading={isLoading}
+        emptyMessage={isLoading ? ' ' : 'No hay tags registrados.'}
+      />
+
+      <Modal show={isDeleting} size="md" popup onClose={() => setIsDeleting(false)}>
+        <Modal.Header />
+        <Modal.Body>
+          <div className="text-center">
+            <TrashIcon className="mx-auto mb-4 h-12 w-12 text-red-500" aria-hidden="true" />
+            <h3 className="mb-5 text-lg font-semibold text-slate-800 dark:text-slate-100">
+              ¿Eliminar este tag?
+            </h3>
+            <p className="mb-6 text-sm text-slate-500 dark:text-slate-400">
+              Esta acción no se puede deshacer.
+            </p>
+            <div className="flex justify-center gap-4">
+              <Button color="gray" onClick={() => setIsDeleting(false)}>
+                Cancelar
+              </Button>
+              <Button color="failure" onClick={handleDelete}>
+                Eliminar
+              </Button>
+            </div>
+          </div>
+        </Modal.Body>
+      </Modal>
+    </DashboardLayout>
+  );
+}
+
+export default TagsList;
+

--- a/frontend/src/services/categories.js
+++ b/frontend/src/services/categories.js
@@ -1,0 +1,35 @@
+import api from './api.js';
+
+export async function listarCategorias(params = {}) {
+  const searchParams = new URLSearchParams();
+
+  if (params.search) {
+    searchParams.set('search', params.search);
+  }
+
+  if (params.withCounts) {
+    searchParams.set('with_counts', params.withCounts ? 'true' : 'false');
+  }
+
+  const query = searchParams.toString();
+  const response = await api.get(`categories/${query ? `?${query}` : ''}`);
+  return response.data;
+}
+
+export async function crearCategoria(data) {
+  return api.post('categories/', data);
+}
+
+export async function obtenerCategoria(id) {
+  const response = await api.get(`categories/${id}/`);
+  return response.data;
+}
+
+export async function actualizarCategoria(id, data) {
+  return api.put(`categories/${id}/`, data);
+}
+
+export async function eliminarCategoria(id) {
+  return api.delete(`categories/${id}/`);
+}
+

--- a/frontend/src/services/posts.js
+++ b/frontend/src/services/posts.js
@@ -1,0 +1,124 @@
+import api from './api.js';
+
+const buildQueryString = (filters = {}) => {
+  const searchParams = new URLSearchParams();
+
+  const {
+    page,
+    pageSize,
+    search,
+    ordering,
+    category,
+    tags,
+    published
+  } = filters;
+
+  if (page) {
+    searchParams.set('page', page);
+  }
+
+  if (pageSize) {
+    searchParams.set('page_size', pageSize);
+  }
+
+  if (search) {
+    searchParams.set('search', search);
+  }
+
+  if (ordering) {
+    searchParams.set('ordering', ordering);
+  }
+
+  if (category) {
+    searchParams.set('category', category);
+  }
+
+  if (Array.isArray(tags)) {
+    tags
+      .filter((tag) => tag !== null && tag !== undefined && tag !== '')
+      .forEach((tag) => {
+        searchParams.append('tags', tag);
+      });
+  }
+
+  if (typeof published === 'boolean') {
+    searchParams.set('published', published ? 'true' : 'false');
+  }
+
+  const queryString = searchParams.toString();
+  return queryString ? `?${queryString}` : '';
+};
+
+const ensureFormData = (payload) => {
+  if (payload instanceof FormData) {
+    return payload;
+  }
+
+  const formData = new FormData();
+  if (!payload || typeof payload !== 'object') {
+    return formData;
+  }
+
+  Object.entries(payload).forEach(([key, value]) => {
+    if (value === undefined || value === null) {
+      return;
+    }
+
+    if (key === 'tags' && Array.isArray(value)) {
+      value.forEach((tagId) => {
+        if (tagId !== undefined && tagId !== null && tagId !== '') {
+          formData.append('tags[]', tagId);
+        }
+      });
+      return;
+    }
+
+    if (Array.isArray(value)) {
+      value.forEach((item) => {
+        if (item !== undefined && item !== null) {
+          formData.append(`${key}[]`, item);
+        }
+      });
+      return;
+    }
+
+    formData.append(key, value);
+  });
+
+  return formData;
+};
+
+const createMultipartConfig = () => ({
+  headers: {
+    'Content-Type': 'multipart/form-data'
+  }
+});
+
+export async function listarPosts(filters = {}) {
+  const query = buildQueryString(filters);
+  const response = await api.get(`posts/${query}`);
+  return response.data;
+}
+
+export async function obtenerPost(idOrSlug) {
+  const response = await api.get(`posts/${idOrSlug}/`);
+  return response.data;
+}
+
+export async function crearPost(payload) {
+  const formData = ensureFormData(payload);
+  return api.post('posts/', formData, createMultipartConfig());
+}
+
+export async function actualizarPost(id, payload) {
+  const formData = ensureFormData(payload);
+  if (formData instanceof FormData && !formData.has('image')) {
+    formData.delete('image');
+  }
+  return api.put(`posts/${id}/`, formData, createMultipartConfig());
+}
+
+export async function eliminarPost(id) {
+  return api.delete(`posts/${id}/`);
+}
+

--- a/frontend/src/services/tags.js
+++ b/frontend/src/services/tags.js
@@ -1,0 +1,31 @@
+import api from './api.js';
+
+export async function listarTags(params = {}) {
+  const searchParams = new URLSearchParams();
+
+  if (params.search) {
+    searchParams.set('search', params.search);
+  }
+
+  const query = searchParams.toString();
+  const response = await api.get(`tags/${query ? `?${query}` : ''}`);
+  return response.data;
+}
+
+export async function crearTag(data) {
+  return api.post('tags/', data);
+}
+
+export async function obtenerTag(id) {
+  const response = await api.get(`tags/${id}/`);
+  return response.data;
+}
+
+export async function actualizarTag(id, data) {
+  return api.put(`tags/${id}/`, data);
+}
+
+export async function eliminarTag(id) {
+  return api.delete(`tags/${id}/`);
+}
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@heroicons/react": "^2.2.0",
         "@hookform/resolvers": "^3.3.4",
+        "@tanstack/react-table": "^8.11.8",
         "axios": "^1.6.8",
         "flowbite": "^2.3.0",
         "flowbite-react": "^0.7.5",
@@ -21,7 +22,10 @@
         "react-helmet-async": "^1.3.0",
         "react-hook-form": "^7.49.3",
         "react-hot-toast": "^2.4.1",
+        "react-quill": "^2.0.0",
         "react-router-dom": "^6.22.3",
+        "react-select": "^5.8.0",
+        "slugify": "^1.6.6",
         "zod": "^3.22.4",
         "zustand": "^4.5.2"
       },
@@ -49,7 +53,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
       "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.27.1",
@@ -105,7 +108,6 @@
       "version": "7.28.3",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.3.tgz",
       "integrity": "sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.28.3",
@@ -139,7 +141,6 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
       "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -149,7 +150,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
       "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.27.1",
@@ -191,7 +191,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -201,7 +200,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
       "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -235,7 +233,6 @@
       "version": "7.28.4",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
       "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.28.4"
@@ -292,7 +289,6 @@
       "version": "7.27.2",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
       "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
@@ -307,7 +303,6 @@
       "version": "7.28.4",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.4.tgz",
       "integrity": "sha512-YEzuboP2qvQavAcjgQNVgsvHIDv6ZpwXvcvjmyySP2DIMuByS/6ioU5G9pYrWHM6T2YDfc7xga9iNzYOs12CFQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
@@ -326,7 +321,6 @@
       "version": "7.28.4",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
       "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -335,6 +329,126 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@emotion/babel-plugin": {
+      "version": "11.13.5",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
+      "integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/runtime": "^7.18.3",
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/serialize": "^1.3.3",
+        "babel-plugin-macros": "^3.1.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/convert-source-map": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/cache": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
+      "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/hash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/react": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
+      "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "hoist-non-react-statics": "^3.3.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@emotion/serialize": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
+      "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/unitless": "^0.10.0",
+        "@emotion/utils": "^1.4.2",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@emotion/sheet": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
+      "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/unitless": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz",
+      "integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@emotion/utils": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+      "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
+      "license": "MIT"
+    },
+    "node_modules/@emotion/weak-memoize": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
+      "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
@@ -1295,6 +1409,39 @@
         "win32"
       ]
     },
+    "node_modules/@tanstack/react-table": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.21.3.tgz",
+      "integrity": "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/table-core": "8.21.3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@tanstack/table-core": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.3.tgz",
+      "integrity": "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1345,6 +1492,40 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "license": "MIT"
+    },
+    "node_modules/@types/parse-json": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
+      "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/quill": {
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/@types/quill/-/quill-1.3.10.tgz",
+      "integrity": "sha512-IhW3fPW+bkt9MLNlycw8u8fWb7oO7W5URC9MfZYHBlA24rex9rs23D5DETChu1zvgVdc5ka64ICjJOgQMr6Shw==",
+      "license": "MIT",
+      "dependencies": {
+        "parchment": "^1.1.2"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.2",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.2.tgz",
+      "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-transition-group": {
+      "version": "4.4.12",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
+      "integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
+      }
     },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
@@ -1489,6 +1670,21 @@
         "proxy-from-env": "^1.1.0"
       }
     },
+    "node_modules/babel-plugin-macros": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "cosmiconfig": "^7.0.0",
+        "resolve": "^1.19.0"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1572,6 +1768,24 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/call-bind": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -1583,6 +1797,31 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/camelcase-css": {
@@ -1657,6 +1896,15 @@
       "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
       "license": "MIT"
     },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1702,6 +1950,31 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cosmiconfig": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cosmiconfig/node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -1751,7 +2024,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -1765,6 +2037,26 @@
         }
       }
     },
+    "node_modules/deep-equal": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.2.tgz",
+      "integrity": "sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arguments": "^1.1.1",
+        "is-date-object": "^1.0.5",
+        "is-regex": "^1.1.4",
+        "object-is": "^1.1.5",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.5.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/deepmerge": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -1772,6 +2064,40 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/delayed-stream": {
@@ -1794,6 +2120,16 @@
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "license": "MIT"
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
+      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -1827,6 +2163,15 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "license": "MIT"
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
@@ -1922,11 +2267,41 @@
         "node": ">=6"
       }
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "license": "MIT"
+    },
+    "node_modules/eventemitter3": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.3.tgz",
+      "integrity": "sha512-jLN68Dx5kyFHaePoXWPsCGW5qdyZQtLYHkxkg02/Mz6g0kYpDx4FyP6XfArhQdlOC4b8Mv+EMxPo/8La7Tzghg==",
+      "license": "MIT"
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/fast-diff": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
+      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==",
+      "license": "Apache-2.0"
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -1976,6 +2351,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+      "license": "MIT"
     },
     "node_modules/flowbite": {
       "version": "2.5.2",
@@ -2144,6 +2525,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/fuse.js": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.1.0.tgz",
@@ -2253,6 +2643,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -2292,6 +2694,31 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/invariant": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
@@ -2300,6 +2727,28 @@
       "dependencies": {
         "loose-envify": "^1.0.0"
       }
+    },
+    "node_modules/is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "license": "MIT"
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -2320,6 +2769,22 @@
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2373,6 +2838,24 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -2413,7 +2896,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
@@ -2421,6 +2903,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "license": "MIT"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -2462,6 +2950,12 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT"
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -2492,6 +2986,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/memoize-one": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
+      "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==",
+      "license": "MIT"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -2600,7 +3100,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mz": {
@@ -2676,11 +3175,72 @@
         "node": ">= 6"
       }
     },
+    "node_modules/object-is": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parchment": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/parchment/-/parchment-1.1.4.tgz",
+      "integrity": "sha512-J5FBQt/pM2inLzg4hEWmzQx/8h8D0CiDxaG3vyp9rKrQRSDgBlhjdP5jQGgosEajXPSQouXGHOmVdgo7QmJuOg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/path-key": {
       "version": "3.1.1",
@@ -2718,6 +3278,15 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -2948,6 +3517,34 @@
       ],
       "license": "MIT"
     },
+    "node_modules/quill": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/quill/-/quill-1.3.7.tgz",
+      "integrity": "sha512-hG/DVzh/TiknWtE6QmWAF/pxoZKYxfe3J/d/+ShUWkDvvkZQVTPeVmUJVu1uE6DDooC4fWTiCLh84ul89oNz5g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "clone": "^2.1.1",
+        "deep-equal": "^1.0.1",
+        "eventemitter3": "^2.0.3",
+        "extend": "^3.0.2",
+        "parchment": "^1.1.4",
+        "quill-delta": "^3.6.2"
+      }
+    },
+    "node_modules/quill-delta": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-3.6.3.tgz",
+      "integrity": "sha512-wdIGBlcX13tCHOXGMVnnTVFtGRLoP0imqxM696fIPwIf5ODIYUHIvHbZcyvGlZFiFhK5XzDC2lpjbxRhnM05Tg==",
+      "license": "MIT",
+      "dependencies": {
+        "deep-equal": "^1.0.1",
+        "extend": "^3.0.2",
+        "fast-diff": "1.1.2"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -3044,6 +3641,21 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/react-quill": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-quill/-/react-quill-2.0.0.tgz",
+      "integrity": "sha512-4qQtv1FtCfLgoD3PXAur5RyxuUbPXQGOHgTlFie3jtxp43mXDtzCKaOgQ3mLyZfi1PUlyjycfivKelFhy13QUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/quill": "^1.3.10",
+        "lodash": "^4.17.4",
+        "quill": "^1.3.7"
+      },
+      "peerDependencies": {
+        "react": "^16 || ^17 || ^18",
+        "react-dom": "^16 || ^17 || ^18"
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -3086,6 +3698,43 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/react-select": {
+      "version": "5.10.2",
+      "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.10.2.tgz",
+      "integrity": "sha512-Z33nHdEFWq9tfnfVXaiM12rbJmk+QjFEztWLtmXqQhz6Al4UZZ9xc0wiatmGtUOCCnHN0WizL3tCMYRENX4rVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.0",
+        "@emotion/cache": "^11.4.0",
+        "@emotion/react": "^11.8.1",
+        "@floating-ui/dom": "^1.0.1",
+        "@types/react-transition-group": "^4.4.0",
+        "memoize-one": "^6.0.0",
+        "prop-types": "^15.6.0",
+        "react-transition-group": "^4.3.0",
+        "use-isomorphic-layout-effect": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -3119,6 +3768,26 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
@@ -3137,6 +3806,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/reusify": {
@@ -3233,6 +3911,38 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/shallowequal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
@@ -3270,6 +3980,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/slugify": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.6.tgz",
+      "integrity": "sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/source-map-js": {
@@ -3376,6 +4104,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/stylis": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
+      "license": "MIT"
     },
     "node_modules/sucrase": {
       "version": "3.35.0",
@@ -3541,6 +4275,20 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/use-isomorphic-layout-effect": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.2.1.tgz",
+      "integrity": "sha512-tpZZ+EX0gaghDAiFR37hj5MgY6ZN55kLiPkJsKxBMZ6GZdOSPJXiOzPM984oPYZ5AnehYx5WQp1+ME8I/P/pRA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/use-sync-external-store": {
@@ -3730,6 +4478,20 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      }
     },
     "node_modules/zod": {
       "version": "3.25.76",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@heroicons/react": "^2.2.0",
     "@hookform/resolvers": "^3.3.4",
+    "@tanstack/react-table": "^8.11.8",
     "axios": "^1.6.8",
     "flowbite": "^2.3.0",
     "flowbite-react": "^0.7.5",
@@ -22,7 +23,10 @@
     "react-helmet-async": "^1.3.0",
     "react-hook-form": "^7.49.3",
     "react-hot-toast": "^2.4.1",
+    "react-quill": "^2.0.0",
     "react-router-dom": "^6.22.3",
+    "react-select": "^5.8.0",
+    "slugify": "^1.6.6",
     "zod": "^3.22.4",
     "zustand": "^4.5.2"
   },


### PR DESCRIPTION
## Summary
- add protected dashboard routes for managing posts, categories and tags
- introduce shared Flowbite-based form inputs, sidebar navigation and reusable data table
- extend axios services to cover CRUD operations including multipart uploads for post images

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f50e1a73fc8327a193d3277189a27e