### PR TITLE
Implement dashboard CRUD flows in the backoffice

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -13,6 +13,11 @@ import ProtectedRoute from './routes/ProtectedRoute.jsx';
 import DashboardLayout from './layouts/DashboardLayout.jsx';
 import DashboardHome from './pages/dashboard/DashboardHome.jsx';
 import DashboardPosts from './pages/dashboard/DashboardPosts.jsx';
+import DashboardPostNew from './pages/dashboard/DashboardPostNew.jsx';
+import DashboardPostEdit from './pages/dashboard/DashboardPostEdit.jsx';
+import DashboardPostDetail from './pages/dashboard/DashboardPostDetail.jsx';
+import DashboardTags from './pages/dashboard/DashboardTags.jsx';
+import DashboardCategories from './pages/dashboard/DashboardCategories.jsx';
 import DashboardComments from './pages/dashboard/DashboardComments.jsx';
 import DashboardSettings from './pages/dashboard/DashboardSettings.jsx';
 import DashboardUsers from './pages/dashboard/DashboardUsers.jsx';
@@ -75,7 +80,16 @@ function App() {
           )}
         >
           <Route index element={<DashboardHome />} />
-          <Route path="posts" element={<DashboardPosts />} />
+          <Route path="posts">
+            <Route index element={<DashboardPosts />} />
+            <Route path="new" element={<DashboardPostNew />} />
+            <Route path=":slug">
+              <Route index element={<DashboardPostDetail />} />
+              <Route path="edit" element={<DashboardPostEdit />} />
+            </Route>
+          </Route>
+          <Route path="tags" element={<DashboardTags />} />
+          <Route path="categories" element={<DashboardCategories />} />
           <Route path="comments" element={<DashboardComments />} />
           <Route path="users" element={<DashboardUsers />} />
           <Route path="settings" element={<DashboardSettings />} />

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -8,6 +8,7 @@ import {
   Home,
   LayoutDashboard,
   LayoutList,
+  MessageSquare,
   LogIn,
   LogOut,
   NotebookPen,
@@ -73,6 +74,12 @@ const dashboardLinks = [
     label: 'Etiquetas',
     icon: Tags,
     match: (path) => path.startsWith('/dashboard/tags')
+  },
+  {
+    to: '/dashboard/comments',
+    label: 'Comentarios',
+    icon: MessageSquare,
+    match: (path) => path.startsWith('/dashboard/comments')
   }
 ];
 

--- a/frontend/src/components/backoffice/ConfirmModal.jsx
+++ b/frontend/src/components/backoffice/ConfirmModal.jsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { Modal } from 'flowbite-react';
 import { AlertTriangle } from 'lucide-react';
@@ -7,6 +8,7 @@ function ConfirmModal({
   open,
   title,
   description,
+  body,
   confirmLabel,
   cancelLabel,
   onCancel,
@@ -14,25 +16,55 @@ function ConfirmModal({
   tone,
   loading
 }) {
+  const confirmButtonRef = useRef(null);
+
+  useEffect(() => {
+    if (open) {
+      const focusTimeout = window.setTimeout(() => {
+        confirmButtonRef.current?.focus();
+      }, 30);
+      return () => window.clearTimeout(focusTimeout);
+    }
+    return undefined;
+  }, [open]);
+
   return (
-    <Modal show={open} size="md" onClose={onCancel} dismissible aria-labelledby="confirm-modal-title">
+    <Modal
+      show={open}
+      size="md"
+      onClose={loading ? undefined : onCancel}
+      dismissible={!loading}
+      aria-labelledby="confirm-modal-title"
+    >
       <Modal.Header className="border-0 pb-2">
         <div className="flex items-center gap-3">
-          <span className={`flex h-10 w-10 items-center justify-center rounded-2xl ${tone === 'danger' ? 'bg-red-500/10 text-red-600 dark:bg-red-500/20 dark:text-red-400' : 'bg-sky-500/10 text-sky-600 dark:bg-sky-400/20 dark:text-sky-300'}`}>
+          <span
+            className={`flex h-10 w-10 items-center justify-center rounded-2xl ${
+              tone === 'danger'
+                ? 'bg-red-500/10 text-red-600 dark:bg-red-500/20 dark:text-red-400'
+                : 'bg-sky-500/10 text-sky-600 dark:bg-sky-400/20 dark:text-sky-300'
+            }`}
+          >
             <AlertTriangle className="h-5 w-5" aria-hidden="true" />
           </span>
           <div>
             <h2 id="confirm-modal-title" className="text-lg font-semibold text-slate-900 dark:text-white">
               {title}
             </h2>
-            {description ? <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">{description}</p> : null}
+            {description ? (
+              <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">{description}</p>
+            ) : null}
           </div>
         </div>
       </Modal.Header>
       <Modal.Body className="border-0 pt-0">
-        <p className="text-sm text-slate-500 dark:text-slate-400">
-          Esta acción no se puede deshacer en el entorno actual. Se enviará al backend cuando la API esté disponible.
-        </p>
+        {body ? (
+          <div className="space-y-3 text-sm text-slate-600 dark:text-slate-300">{body}</div>
+        ) : (
+          <p className="text-sm text-slate-500 dark:text-slate-400">
+            Esta acción no se puede deshacer. Se enviará una petición al backend para completar el proceso.
+          </p>
+        )}
       </Modal.Body>
       <Modal.Footer className="border-0 pt-0">
         <div className="flex w-full justify-end gap-3">
@@ -40,6 +72,7 @@ function ConfirmModal({
             {cancelLabel}
           </Button>
           <Button
+            ref={confirmButtonRef}
             type="button"
             variant={tone === 'danger' ? 'destructive' : 'default'}
             onClick={onConfirm}
@@ -58,6 +91,7 @@ ConfirmModal.propTypes = {
   open: PropTypes.bool.isRequired,
   title: PropTypes.string.isRequired,
   description: PropTypes.node,
+  body: PropTypes.node,
   confirmLabel: PropTypes.string,
   cancelLabel: PropTypes.string,
   onCancel: PropTypes.func.isRequired,
@@ -68,6 +102,7 @@ ConfirmModal.propTypes = {
 
 ConfirmModal.defaultProps = {
   description: null,
+  body: null,
   confirmLabel: 'Confirmar',
   cancelLabel: 'Cancelar',
   tone: 'default',

--- a/frontend/src/components/backoffice/DataTable.jsx
+++ b/frontend/src/components/backoffice/DataTable.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import {
   flexRender,
@@ -8,334 +8,81 @@ import {
   useReactTable
 } from '@tanstack/react-table';
 import { useAutoAnimate } from '@formkit/auto-animate/react';
-import { Badge, Spinner } from 'flowbite-react';
-import { Eye, Pencil, Trash2, ListFilter, Undo2, Tag as TagIcon, Search } from 'lucide-react';
-import { Button } from '../ui/button.jsx';
-import { Input } from '../ui/input.jsx';
+import { Spinner } from 'flowbite-react';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { useDashboardStore, selectDashboardDensity } from '../../store/dashboard.js';
 import EmptyState from './EmptyState.jsx';
-import {
-  useDashboardStore,
-  selectDashboardPagination,
-  selectDashboardSorting
-} from '../../store/dashboard.js';
+import { Button } from '../ui/button.jsx';
 
-const dateFormatter = new Intl.DateTimeFormat('es-ES', {
-  day: '2-digit',
-  month: 'short',
-  year: 'numeric'
-});
-
-const statusConfig = {
-  published: {
-    label: 'Publicado',
-    className:
-      'inline-flex items-center rounded-full bg-emerald-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-emerald-600 dark:bg-emerald-500/20 dark:text-emerald-300'
-  },
-  draft: {
-    label: 'Borrador',
-    className:
-      'inline-flex items-center rounded-full bg-amber-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-amber-600 dark:bg-amber-500/20 dark:text-amber-300'
-  },
-  scheduled: {
-    label: 'Programado',
-    className:
-      'inline-flex items-center rounded-full bg-sky-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-sky-600 dark:bg-sky-500/20 dark:text-sky-300'
-  }
-};
-
-const statuses = [
-  { id: 'all', label: 'Todos' },
-  { id: 'published', label: 'Publicados' },
-  { id: 'draft', label: 'Borradores' },
-  { id: 'scheduled', label: 'Programados' }
-];
-
-function DataTable({ data, isLoading, onView, onEdit, onDelete }) {
-  const search = useDashboardStore((state) => state.search);
-  const setSearch = useDashboardStore((state) => state.setSearch);
-  const statusFilter = useDashboardStore((state) => state.statusFilter);
-  const setStatusFilter = useDashboardStore((state) => state.setStatusFilter);
-  const tagFilter = useDashboardStore((state) => state.tagFilter);
-  const setTagFilter = useDashboardStore((state) => state.setTagFilter);
-  const resetFilters = useDashboardStore((state) => state.resetFilters);
-  const density = useDashboardStore((state) => state.density);
-  const setDensity = useDashboardStore((state) => state.setDensity);
-  const { pageIndex, pageSize } = useDashboardStore(selectDashboardPagination);
-  const { sortBy, sortDirection } = useDashboardStore(selectDashboardSorting);
-  const setPagination = useDashboardStore((state) => state.setPagination);
-  const setSort = useDashboardStore((state) => state.setSort);
-  const [sorting, setSorting] = useState(() => [
-    { id: sortBy, desc: sortDirection === 'desc' }
-  ]);
+function DataTable({
+  columns,
+  data,
+  isLoading,
+  pageIndex,
+  pageSize,
+  pageCount,
+  onPageChange,
+  onPageSizeChange,
+  sorting,
+  onSortingChange,
+  renderToolbar,
+  emptyState,
+  loadingMessage,
+  density: densityProp
+}) {
+  const globalDensity = useDashboardStore(selectDashboardDensity);
+  const density = densityProp ?? globalDensity ?? 'comfortable';
   const [tableBodyRef] = useAutoAnimate();
 
-  useEffect(() => {
-    setSorting([{ id: sortBy, desc: sortDirection === 'desc' }]);
-  }, [sortBy, sortDirection]);
-
-  const availableTags = useMemo(() => {
-    const tagMap = new Map();
-    data.forEach((post) => {
-      (post.tags ?? []).forEach((tag) => {
-        if (typeof tag !== 'string') return;
-        const normalized = tag.trim();
-        if (!normalized) return;
-        const key = normalized.toLowerCase();
-        if (!tagMap.has(key)) {
-          tagMap.set(key, normalized);
-        }
-      });
-    });
-    return Array.from(tagMap.values()).sort((a, b) => a.localeCompare(b, 'es'));
-  }, [data]);
-
-  const filteredData = useMemo(() => {
-    const normalizedSearch = search.trim();
-    return data.filter((post) => {
-      const tags = post.tags ?? [];
-      const matchesSearch = normalizedSearch
-        ? post.title.toLowerCase().includes(normalizedSearch) || tags.some((tag) => tag.toLowerCase().includes(normalizedSearch))
-        : true;
-      const matchesStatus = statusFilter === 'all' ? true : post.status === statusFilter;
-      const matchesTags =
-        tagFilter.length === 0
-          ? true
-          : tagFilter.every((tag) => tags.map((t) => t.toLowerCase()).includes(tag));
-      return matchesSearch && matchesStatus && matchesTags;
-    });
-  }, [data, search, statusFilter, tagFilter]);
-
-  const columns = useMemo(
-    () => [
-      {
-        accessorKey: 'title',
-        header: () => <span className="text-xs font-semibold uppercase tracking-wide text-slate-400">Título</span>,
-        cell: ({ row }) => {
-          const original = row.original;
-          return (
-            <div className="max-w-xs space-y-1">
-              <p className="font-semibold text-slate-900 dark:text-white">{original.title}</p>
-              <p className="text-xs text-slate-500 dark:text-slate-400">{original.summary}</p>
-            </div>
-          );
-        }
-      },
-      {
-        accessorKey: 'status',
-        header: () => <span className="text-xs font-semibold uppercase tracking-wide text-slate-400">Estado</span>,
-        cell: ({ row }) => {
-          const { status } = row.original;
-          const config = statusConfig[status] ?? statusConfig.published;
-          return <span className={config.className}>{config.label}</span>;
-        }
-      },
-      {
-        accessorKey: 'tags',
-        header: () => <span className="text-xs font-semibold uppercase tracking-wide text-slate-400">Etiquetas</span>,
-        cell: ({ row }) => (
-          <div className="flex flex-wrap items-center gap-2">
-            {row.original.tags.slice(0, 3).map((tag) => (
-              <Badge key={tag} color="info" size="sm" className="rounded-full bg-sky-500/10 text-sky-600 dark:bg-sky-500/10 dark:text-sky-300">
-                #{tag}
-              </Badge>
-            ))}
-            {row.original.tags.length > 3 ? (
-              <span className="text-xs text-slate-400">+{row.original.tags.length - 3}</span>
-            ) : null}
-          </div>
-        )
-      },
-      {
-        accessorKey: 'publishedAt',
-        header: () => <span className="text-xs font-semibold uppercase tracking-wide text-slate-400">Fecha</span>,
-        cell: ({ row }) => {
-          const date = new Date(row.original.publishedAt);
-          return <span className="text-sm text-slate-500 dark:text-slate-400">{dateFormatter.format(date)}</span>;
-        }
-      },
-      {
-        id: 'actions',
-        header: () => <span className="sr-only">Acciones</span>,
-        enableSorting: false,
-        cell: ({ row }) => (
-          <div className="flex items-center justify-end gap-2">
-            <Button
-              type="button"
-              size="icon"
-              variant="ghost"
-              className="h-9 w-9"
-              onClick={() => onView(row.original)}
-              aria-label={`Ver post ${row.original.title}`}
-            >
-              <Eye className="h-4 w-4" aria-hidden="true" />
-            </Button>
-            <Button
-              type="button"
-              size="icon"
-              variant="ghost"
-              className="h-9 w-9"
-              onClick={() => onEdit(row.original)}
-              aria-label={`Editar post ${row.original.title}`}
-            >
-              <Pencil className="h-4 w-4" aria-hidden="true" />
-            </Button>
-            <Button
-              type="button"
-              size="icon"
-              variant="ghost"
-              className="h-9 w-9 text-red-500 hover:text-red-600 dark:text-red-400 dark:hover:text-red-300"
-              onClick={() => onDelete(row.original)}
-              aria-label={`Eliminar post ${row.original.title}`}
-            >
-              <Trash2 className="h-4 w-4" aria-hidden="true" />
-            </Button>
-          </div>
-        )
-      }
-    ],
-    [onDelete, onEdit, onView]
-  );
-
   const table = useReactTable({
-    data: filteredData,
+    data,
     columns,
     state: {
       sorting,
       pagination: { pageIndex, pageSize }
     },
-    onSortingChange: (updater) => {
-      const next = typeof updater === 'function' ? updater(sorting) : updater;
-      setSorting(next);
-      const primary = next[0];
-      if (primary) {
-        setSort({ sortBy: primary.id, sortDirection: primary.desc ? 'desc' : 'asc' });
-      } else {
-        setSort({ sortBy: 'publishedAt', sortDirection: 'desc' });
-      }
-    },
-    onPaginationChange: (updater) => {
-      const next =
-        typeof updater === 'function'
-          ? updater({ pageIndex, pageSize })
-          : updater;
-      setPagination(next);
-    },
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
-    manualPagination: false,
-    autoResetPageIndex: false
+    manualPagination: true,
+    manualSorting: true,
+    pageCount,
+    onSortingChange,
+    onPaginationChange: (updater) => {
+      const next = typeof updater === 'function' ? updater({ pageIndex, pageSize }) : updater;
+      if (next.pageIndex !== pageIndex && typeof onPageChange === 'function') {
+        onPageChange(next.pageIndex);
+      }
+      if (next.pageSize !== pageSize && typeof onPageSizeChange === 'function') {
+        onPageSizeChange(next.pageSize);
+      }
+    }
   });
 
-  useEffect(() => {
-    const totalPages = table.getPageCount();
-    if (pageIndex > 0 && pageIndex >= totalPages) {
-      setPagination({ pageIndex: Math.max(totalPages - 1, 0), pageSize });
-    }
-  }, [pageIndex, pageSize, setPagination, table]);
-
-  const handleTagToggle = (tag) => {
-    const normalized = tag.toLowerCase();
-    if (tagFilter.includes(normalized)) {
-      setTagFilter(tagFilter.filter((item) => item !== normalized));
-    } else {
-      setTagFilter([...tagFilter, normalized]);
-    }
-  };
-
+  const totalRows = data.length;
   const tablePadding = density === 'compact' ? 'py-2 text-sm' : 'py-4';
+
+  const paginationLabel = useMemo(() => {
+    if (pageCount === 0) {
+      return 'Página 1 de 1';
+    }
+    return `Página ${pageIndex + 1} de ${pageCount}`;
+  }, [pageCount, pageIndex]);
 
   return (
     <section className="space-y-6 rounded-3xl border border-slate-200/70 bg-white/80 p-6 shadow-sm backdrop-blur dark:border-slate-800/70 dark:bg-slate-900/70">
-      <header className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
-        <div className="flex items-center gap-3 text-slate-500 dark:text-slate-400">
-          <ListFilter className="h-5 w-5" aria-hidden="true" />
-          <div>
-            <h2 className="text-lg font-semibold text-slate-900 dark:text-white">Listado de posts</h2>
-            <p className="text-sm">Filtra por estado, etiquetas o busca por título.</p>
-          </div>
-        </div>
-        <div className="flex items-center gap-2">
-          <Button
-            type="button"
-            variant={density === 'comfortable' ? 'secondary' : 'ghost'}
-            size="sm"
-            onClick={() => setDensity('comfortable')}
-          >
-            Vista cómoda
-          </Button>
-          <Button
-            type="button"
-            variant={density === 'compact' ? 'secondary' : 'ghost'}
-            size="sm"
-            onClick={() => setDensity('compact')}
-          >
-            Vista compacta
-          </Button>
-          <Button type="button" variant="ghost" size="sm" onClick={resetFilters}>
-            <Undo2 className="mr-2 h-4 w-4" aria-hidden="true" />
-            Reiniciar filtros
-          </Button>
-        </div>
-      </header>
-      <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
-        <div className="flex flex-wrap items-center gap-2">
-          {statuses.map((status) => (
-            <Button
-              key={status.id}
-              type="button"
-              size="sm"
-              variant={statusFilter === status.id ? 'secondary' : 'ghost'}
-              onClick={() => setStatusFilter(status.id)}
-            >
-              {status.label}
-            </Button>
-          ))}
-        </div>
-        <div className="relative w-full max-w-xs">
-          <Search className="pointer-events-none absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" aria-hidden="true" />
-          <Input
-            type="search"
-            value={search}
-            onChange={(event) => setSearch(event.target.value)}
-            placeholder="Buscar por título"
-            aria-label="Buscar posts"
-            className="w-full rounded-full border-slate-200 bg-white pl-10 pr-4 text-sm dark:border-slate-800 dark:bg-slate-950"
-          />
-        </div>
-      </div>
-      {availableTags.length > 0 ? (
-        <div className="flex flex-wrap items-center gap-2 text-sm">
-          <span className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-slate-400">
-            <TagIcon className="h-4 w-4" aria-hidden="true" /> Etiquetas rápidas
-          </span>
-          {availableTags.map((tag) => {
-            const normalized = tag.toLowerCase();
-            const isActive = tagFilter.includes(normalized);
-            return (
-              <Button
-                key={tag}
-                type="button"
-                size="sm"
-                variant={isActive ? 'secondary' : 'ghost'}
-                onClick={() => handleTagToggle(tag)}
-              >
-                #{tag}
-              </Button>
-            );
-          })}
-        </div>
-      ) : null}
+      {renderToolbar ? <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">{renderToolbar}</div> : null}
       <div className="overflow-hidden rounded-3xl border border-slate-200/70 shadow-sm dark:border-slate-800/70">
         <div className="overflow-x-auto">
-          <table className="min-w-full divide-y divide-slate-200 dark:divide-slate-800">
+          <table className="min-w-full divide-y divide-slate-200 dark:divide-slate-800" role="table">
             <thead className="bg-slate-50/80 dark:bg-slate-900/70">
               {table.getHeaderGroups().map((headerGroup) => (
-                <tr key={headerGroup.id}>
+                <tr key={headerGroup.id} role="row">
                   {headerGroup.headers.map((header) => (
                     <th
                       key={header.id}
                       scope="col"
+                      role="columnheader"
                       className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-400"
                     >
                       {header.isPlaceholder ? null : (
@@ -356,21 +103,24 @@ function DataTable({ data, isLoading, onView, onEdit, onDelete }) {
                 </tr>
               ))}
             </thead>
-            <tbody ref={tableBodyRef} className="divide-y divide-slate-200 bg-white dark:divide-slate-800 dark:bg-slate-950/30">
+            <tbody
+              ref={tableBodyRef}
+              className="divide-y divide-slate-200 bg-white dark:divide-slate-800 dark:bg-slate-950/30"
+            >
               {isLoading ? (
                 <tr>
                   <td colSpan={columns.length} className="px-6 py-16 text-center">
                     <div className="flex flex-col items-center gap-3 text-slate-500 dark:text-slate-400">
                       <Spinner size="lg" />
-                      <span>Cargando posts...</span>
+                      <span>{loadingMessage ?? 'Cargando información...'}</span>
                     </div>
                   </td>
                 </tr>
-              ) : table.getRowModel().rows.length > 0 ? (
+              ) : totalRows > 0 ? (
                 table.getRowModel().rows.map((row) => (
-                  <tr key={row.id} className="transition hover:bg-slate-50/70 dark:hover:bg-slate-800/40">
+                  <tr key={row.id} className="transition hover:bg-slate-50/70 dark:hover:bg-slate-800/40" role="row">
                     {row.getVisibleCells().map((cell) => (
-                      <td key={cell.id} className={`px-6 ${tablePadding}`}>
+                      <td key={cell.id} className={`px-6 ${tablePadding}`} role="cell">
                         {flexRender(cell.column.columnDef.cell, cell.getContext())}
                       </td>
                     ))}
@@ -380,8 +130,9 @@ function DataTable({ data, isLoading, onView, onEdit, onDelete }) {
                 <tr>
                   <td colSpan={columns.length} className="px-6 py-16">
                     <EmptyState
-                      title="Sin posts que mostrar"
-                      description="Ajusta los filtros o crea un nuevo post cuando el backend esté disponible."
+                      title={emptyState?.title ?? 'Sin información para mostrar'}
+                      description={emptyState?.description ?? 'No encontramos registros con los filtros actuales.'}
+                      action={emptyState?.action}
                     />
                   </td>
                 </tr>
@@ -391,9 +142,7 @@ function DataTable({ data, isLoading, onView, onEdit, onDelete }) {
         </div>
       </div>
       <footer className="flex flex-col items-center justify-between gap-4 text-sm text-slate-500 dark:text-slate-400 sm:flex-row">
-        <div>
-          Mostrando {Math.min((pageIndex + 1) * pageSize, filteredData.length)} de {filteredData.length} posts
-        </div>
+        <div>{paginationLabel}</div>
         <div className="flex items-center gap-2">
           <Button
             type="button"
@@ -401,11 +150,13 @@ function DataTable({ data, isLoading, onView, onEdit, onDelete }) {
             size="sm"
             onClick={() => table.previousPage()}
             disabled={!table.getCanPreviousPage()}
+            className="inline-flex items-center gap-2"
           >
+            <ChevronLeft className="h-4 w-4" aria-hidden="true" />
             Anterior
           </Button>
-          <span>
-            Página {pageIndex + 1} de {Math.max(table.getPageCount(), 1)}
+          <span className="px-2 text-xs font-semibold uppercase tracking-wide text-slate-400">
+            {pageIndex + 1} / {Math.max(pageCount, 1)}
           </span>
           <Button
             type="button"
@@ -413,8 +164,10 @@ function DataTable({ data, isLoading, onView, onEdit, onDelete }) {
             size="sm"
             onClick={() => table.nextPage()}
             disabled={!table.getCanNextPage()}
+            className="inline-flex items-center gap-2"
           >
             Siguiente
+            <ChevronRight className="h-4 w-4" aria-hidden="true" />
           </Button>
         </div>
       </footer>
@@ -423,27 +176,42 @@ function DataTable({ data, isLoading, onView, onEdit, onDelete }) {
 }
 
 DataTable.propTypes = {
-  data: PropTypes.arrayOf(
-    PropTypes.shape({
-      id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
-      title: PropTypes.string.isRequired,
-      summary: PropTypes.string.isRequired,
-      status: PropTypes.oneOf(['published', 'draft', 'scheduled']).isRequired,
-      tags: PropTypes.arrayOf(PropTypes.string).isRequired,
-      publishedAt: PropTypes.string.isRequired
-    })
-  ).isRequired,
+  columns: PropTypes.arrayOf(PropTypes.object).isRequired,
+  data: PropTypes.arrayOf(PropTypes.object).isRequired,
   isLoading: PropTypes.bool,
-  onView: PropTypes.func,
-  onEdit: PropTypes.func,
-  onDelete: PropTypes.func
+  pageIndex: PropTypes.number,
+  pageSize: PropTypes.number,
+  pageCount: PropTypes.number,
+  onPageChange: PropTypes.func,
+  onPageSizeChange: PropTypes.func,
+  sorting: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    desc: PropTypes.bool
+  })),
+  onSortingChange: PropTypes.func,
+  renderToolbar: PropTypes.node,
+  emptyState: PropTypes.shape({
+    title: PropTypes.string,
+    description: PropTypes.node,
+    action: PropTypes.node
+  }),
+  loadingMessage: PropTypes.node,
+  density: PropTypes.oneOf(['comfortable', 'compact'])
 };
 
 DataTable.defaultProps = {
   isLoading: false,
-  onView: () => {},
-  onEdit: () => {},
-  onDelete: () => {}
+  pageIndex: 0,
+  pageSize: 10,
+  pageCount: 1,
+  onPageChange: undefined,
+  onPageSizeChange: undefined,
+  sorting: [],
+  onSortingChange: undefined,
+  renderToolbar: null,
+  emptyState: undefined,
+  loadingMessage: null,
+  density: undefined
 };
 
 export default DataTable;

--- a/frontend/src/components/backoffice/PostForm.jsx
+++ b/frontend/src/components/backoffice/PostForm.jsx
@@ -1,0 +1,485 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import PropTypes from 'prop-types';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import slugify from 'slugify';
+import ReactQuill from 'react-quill';
+import 'react-quill/dist/quill.snow.css';
+import { toast } from 'sonner';
+import InputField from '../forms/Input.jsx';
+import TextareaField from '../forms/Textarea.jsx';
+import SelectField from '../forms/Select.jsx';
+import MultiSelectField from '../forms/MultiSelect.jsx';
+import { Button } from '../ui/button.jsx';
+import {
+  listCategories,
+  listTags,
+  getPost,
+  createPost,
+  updatePost
+} from '../../services/api.js';
+
+const tagOptionSchema = z.object({
+  value: z.string().trim().min(1, 'El tag no puede estar vacío.'),
+  label: z.string()
+});
+
+const slugRegex = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+const postSchema = z
+  .object({
+    title: z.string().trim().min(3, 'El título debe tener al menos 3 caracteres.').max(120, 'El título es demasiado largo.'),
+    slug: z
+      .string()
+      .trim()
+      .optional()
+      .refine((value) => !value || slugRegex.test(value), 'El slug solo puede contener letras, números y guiones.'),
+    excerpt: z
+      .string()
+      .optional()
+      .transform((value) => value?.trim() ?? '')
+      .refine((value) => !value || value.length <= 280, 'El resumen debe tener 280 caracteres o menos.'),
+    content: z.string().min(1, 'El contenido es obligatorio.'),
+    category: z.string().optional(),
+    tags: z.array(tagOptionSchema).default([]),
+    image: z.string().trim().url('La URL de la imagen debe ser válida.'),
+    thumb: z.string().trim().url('La URL de la miniatura debe ser válida.'),
+    imageAlt: z.string().trim().min(3, 'El texto alternativo debe tener al menos 3 caracteres.'),
+    author: z.string().trim().min(3, 'Indica el nombre de la persona autora.'),
+    status: z.enum(['published', 'scheduled']).default('published'),
+    published_at: z.string().min(1, 'Selecciona una fecha de publicación.')
+  })
+  .superRefine((values, ctx) => {
+    const plain = values.content
+      ?.replace(/<[^>]*>/g, ' ')
+      .replace(/&nbsp;/g, ' ')
+      .trim();
+    if (!plain || plain.length < 20) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['content'],
+        message: 'El contenido debe tener al menos 20 caracteres.'
+      });
+    }
+
+    if (values.status === 'scheduled') {
+      const selectedDate = new Date(values.published_at);
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+      if (Number.isNaN(selectedDate.getTime()) || selectedDate <= today) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['published_at'],
+          message: 'Selecciona una fecha futura para programar la publicación.'
+        });
+      }
+    }
+  });
+
+const quillModules = {
+  toolbar: [
+    [{ header: [1, 2, 3, false] }],
+    ['bold', 'italic', 'underline', 'strike'],
+    [{ list: 'ordered' }, { list: 'bullet' }],
+    ['link', 'blockquote', 'code-block'],
+    ['clean']
+  ]
+};
+
+const defaultValues = {
+  title: '',
+  slug: '',
+  excerpt: '',
+  content: '',
+  category: '',
+  tags: [],
+  image: '',
+  thumb: '',
+  imageAlt: '',
+  author: '',
+  status: 'published',
+  published_at: new Date().toISOString().slice(0, 10)
+};
+
+const deriveStatusFromDate = (value) => {
+  if (!value) {
+    return 'published';
+  }
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return 'published';
+  }
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  if (parsed > today) {
+    return 'scheduled';
+  }
+  return 'published';
+};
+
+const normalizeCollection = (payload) => {
+  if (Array.isArray(payload)) return payload;
+  if (payload?.results) return payload.results;
+  if (payload?.data) return payload.data;
+  return [];
+};
+
+function PostForm({ mode, slug, onCancel, onSuccess }) {
+  const {
+    control,
+    handleSubmit,
+    reset,
+    watch,
+    setValue,
+    setError,
+    formState: { isSubmitting, errors }
+  } = useForm({
+    resolver: zodResolver(postSchema),
+    defaultValues
+  });
+
+  const [categoryOptions, setCategoryOptions] = useState([]);
+  const [tagOptions, setTagOptions] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [contentError, setContentError] = useState(null);
+
+  const titleValue = watch('title');
+  const slugValue = watch('slug');
+  const contentValue = watch('content');
+  const statusValue = watch('status');
+  const autoSlugRef = useRef('');
+
+  useEffect(() => {
+    const newSlug = slugify(titleValue ?? '', { lower: true, strict: true });
+    const shouldUpdateSlug = !slugValue || slugValue === autoSlugRef.current;
+    autoSlugRef.current = newSlug;
+    if (shouldUpdateSlug) {
+      setValue('slug', newSlug, { shouldDirty: false, shouldValidate: true });
+    }
+  }, [titleValue, slugValue, setValue]);
+
+  const fetchTaxonomies = useCallback(async () => {
+    try {
+      const [categoriesResponse, tagsResponse] = await Promise.all([
+        listCategories({ withCounts: true }),
+        listTags()
+      ]);
+
+      const categories = normalizeCollection(categoriesResponse).map((category) => ({
+        value: category.slug ?? category.id,
+        label: category.name ?? category.title ?? 'Sin nombre',
+        description: category.description ?? ''
+      }));
+      setCategoryOptions(categories);
+
+      const normalizedTags = normalizeCollection(tagsResponse).map((tag) => {
+        const name = tag.name ?? tag.slug ?? String(tag);
+        return {
+          value: name,
+          label: tag.usage ? `${name} (${tag.usage})` : name
+        };
+      });
+      setTagOptions(normalizedTags);
+    } catch (error) {
+      toast.error('No fue posible cargar categorías y etiquetas.');
+    }
+  }, []);
+
+  const populatePost = useCallback(
+    async (postSlug) => {
+      if (mode !== 'edit' || !postSlug) {
+        return;
+      }
+      try {
+        const post = await getPost(postSlug);
+        const tagsData = Array.isArray(post?.tags) ? post.tags : [];
+        const categoriesData = Array.isArray(post?.categories) ? post.categories : [];
+
+        const mappedTags = tagsData.map((tag) => ({
+          value: typeof tag === 'string' ? tag : tag?.name,
+          label: typeof tag === 'string' ? tag : tag?.name
+        }));
+
+        const statusFromDate = deriveStatusFromDate(post?.created_at ?? post?.date ?? null);
+        const publishedDate = (post?.created_at ?? post?.date ?? new Date().toISOString()).slice(0, 10);
+
+        reset({
+          title: post?.title ?? '',
+          slug: post?.slug ?? '',
+          excerpt: post?.excerpt ?? '',
+          content: post?.content ?? '',
+          category: categoriesData[0] ?? '',
+          tags: mappedTags,
+          image: post?.image ?? '',
+          thumb: post?.thumb ?? '',
+          imageAlt: post?.imageAlt ?? '',
+          author: post?.author ?? '',
+          status: statusFromDate,
+          published_at: publishedDate
+        });
+
+        setTagOptions((previous) => {
+          const map = new Map(previous.map((option) => [option.value.toLowerCase(), option]));
+          mappedTags.forEach((option) => {
+            if (!map.has(option.value.toLowerCase())) {
+              map.set(option.value.toLowerCase(), option);
+            }
+          });
+          return Array.from(map.values());
+        });
+      } catch (error) {
+        toast.error('No se pudo cargar el post solicitado.');
+        if (onCancel) {
+          onCancel();
+        }
+      }
+    },
+    [mode, onCancel, reset]
+  );
+
+  useEffect(() => {
+    const loadData = async () => {
+      setIsLoading(true);
+      await fetchTaxonomies();
+      if (mode === 'edit' && slug) {
+        await populatePost(slug);
+      }
+      setIsLoading(false);
+    };
+
+    loadData();
+  }, [fetchTaxonomies, mode, populatePost, slug]);
+
+  useEffect(() => {
+    const plain = contentValue?.replace(/<[^>]*>/g, ' ').replace(/&nbsp;/g, ' ').trim();
+    if (plain && plain.length >= 20) {
+      setContentError(null);
+    }
+  }, [contentValue]);
+
+  const handleCreateTag = (inputValue) => {
+    const value = inputValue.trim();
+    if (!value) {
+      return;
+    }
+    const option = { value, label: value };
+    setTagOptions((previous) => {
+      if (previous.some((item) => item.value.toLowerCase() === value.toLowerCase())) {
+        return previous;
+      }
+      return [...previous, option];
+    });
+  };
+
+  const onSubmit = async (values) => {
+    const payload = {
+      title: values.title.trim(),
+      slug: values.slug?.trim() ? values.slug.trim() : undefined,
+      excerpt: values.excerpt ?? '',
+      content: values.content,
+      categories: values.category ? [values.category] : [],
+      tags: (values.tags ?? []).map((tag) => tag.value),
+      image: values.image.trim(),
+      thumb: values.thumb.trim(),
+      imageAlt: values.imageAlt.trim(),
+      author: values.author.trim(),
+      date: values.published_at
+    };
+
+    try {
+      const response = mode === 'edit' ? await updatePost(slug, payload) : await createPost(payload);
+      toast.success(mode === 'edit' ? 'Post actualizado correctamente.' : 'Post creado correctamente.');
+      if (onSuccess) {
+        onSuccess(response);
+      }
+    } catch (error) {
+      const data = error?.data;
+      if (data && typeof data === 'object') {
+        let handled = false;
+        Object.entries(data).forEach(([field, messages]) => {
+          if (Array.isArray(messages) && messages.length > 0) {
+            handled = true;
+            const message = messages[0];
+            if (field === 'content') {
+              setContentError(message);
+            } else if (field === 'date') {
+              setError('published_at', { type: 'server', message });
+            } else if (field === 'slug') {
+              setError('slug', { type: 'server', message });
+            } else {
+              setError(field, { type: 'server', message });
+            }
+          }
+        });
+        if (!handled) {
+          toast.error('Revisa los datos del formulario e inténtalo nuevamente.');
+        }
+      } else {
+        toast.error(error?.message ?? 'No se pudo guardar el post.');
+      }
+    }
+  };
+
+  const displayedContentError = errors?.content?.message ?? contentError;
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-[40vh] items-center justify-center text-slate-500 dark:text-slate-400">
+        <span className="animate-pulse text-sm">Cargando formulario...</span>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-6" noValidate>
+      <div className="space-y-6 rounded-3xl border border-slate-200/70 bg-white/80 p-6 shadow-sm backdrop-blur dark:border-slate-800/70 dark:bg-slate-900/70">
+        <div className="grid gap-6 lg:grid-cols-2">
+          <InputField
+            control={control}
+            name="title"
+            label="Título"
+            placeholder="Ingresa el título del post"
+            autoComplete="off"
+          />
+          <InputField
+            control={control}
+            name="slug"
+            label="Slug"
+            placeholder="auto-generado"
+            helperText="Este valor se utilizará en la URL pública."
+            autoComplete="off"
+          />
+        </div>
+        <TextareaField
+          control={control}
+          name="excerpt"
+          label="Resumen"
+          rows={4}
+          placeholder="Introduce un resumen breve del post"
+        />
+        <div className="space-y-2">
+          <label className="text-sm font-medium text-slate-700 dark:text-slate-200" htmlFor="post-content">
+            Contenido
+          </label>
+          <ReactQuill
+            id="post-content"
+            theme="snow"
+            value={contentValue}
+            onChange={(value) => setValue('content', value, { shouldDirty: true })}
+            modules={quillModules}
+            aria-label="Contenido del post"
+          />
+          {displayedContentError ? (
+            <p className="text-xs text-red-500">{displayedContentError}</p>
+          ) : (
+            <p className="text-xs text-slate-500 dark:text-slate-400">
+              Utiliza el editor para dar formato al contenido del post.
+            </p>
+          )}
+        </div>
+        <div className="grid gap-6 lg:grid-cols-2">
+          <SelectField
+            control={control}
+            name="category"
+            label="Categoría"
+            placeholder="Selecciona una categoría"
+            helperText="Puedes crear nuevas categorías desde la sección correspondiente."
+          >
+            <option value="">Sin categoría</option>
+            {categoryOptions.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </SelectField>
+          <MultiSelectField
+            control={control}
+            name="tags"
+            label="Tags"
+            options={tagOptions}
+            placeholder="Selecciona tags relacionados"
+            helperText="Puedes elegir varias etiquetas o crear nuevas para organizar el contenido."
+            isCreatable
+            onCreateOption={handleCreateTag}
+          />
+        </div>
+        <div className="grid gap-6 lg:grid-cols-2">
+          <InputField
+            control={control}
+            name="image"
+            label="Imagen destacada (URL)"
+            placeholder="https://..."
+            helperText="Utiliza una URL pública accesible desde el backend."
+          />
+          <InputField
+            control={control}
+            name="thumb"
+            label="Miniatura (URL)"
+            placeholder="https://..."
+            helperText="Será usada para listados y tarjetas."
+          />
+        </div>
+        <div className="grid gap-6 lg:grid-cols-2">
+          <InputField
+            control={control}
+            name="imageAlt"
+            label="Texto alternativo de la imagen"
+            placeholder="Describe brevemente la imagen"
+          />
+          <InputField
+            control={control}
+            name="author"
+            label="Autor o autora"
+            placeholder="Nombre visible en el post"
+          />
+        </div>
+        <div className="grid gap-6 lg:grid-cols-2">
+          <SelectField
+            control={control}
+            name="status"
+            label="Estado"
+            helperText="Selecciona si el post se publica ahora o queda programado."
+          >
+            <option value="published">Publicado</option>
+            <option value="scheduled">Programado</option>
+          </SelectField>
+          <InputField
+            control={control}
+            name="published_at"
+            type="date"
+            label={statusValue === 'scheduled' ? 'Fecha programada' : 'Fecha de publicación'}
+          />
+        </div>
+      </div>
+      <div className="flex flex-col gap-3 sm:flex-row sm:justify-end">
+        <Button type="button" variant="ghost" onClick={onCancel} disabled={isSubmitting}>
+          Cancelar
+        </Button>
+        <Button type="submit" disabled={isSubmitting}>
+          {isSubmitting
+            ? 'Guardando...'
+            : mode === 'edit'
+              ? 'Guardar cambios'
+              : 'Crear post'}
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+PostForm.propTypes = {
+  mode: PropTypes.oneOf(['create', 'edit']),
+  slug: PropTypes.string,
+  onCancel: PropTypes.func,
+  onSuccess: PropTypes.func
+};
+
+PostForm.defaultProps = {
+  mode: 'create',
+  slug: null,
+  onCancel: null,
+  onSuccess: null
+};
+
+export default PostForm;

--- a/frontend/src/components/backoffice/Topbar.jsx
+++ b/frontend/src/components/backoffice/Topbar.jsx
@@ -26,7 +26,8 @@ function Topbar({
   onOpenMobile,
   showSearch,
   searchValue,
-  onSearchChange
+  onSearchChange,
+  searchPlaceholder
 }) {
   const { user, logout, isAuthenticated } = useAuth();
   const navigate = useNavigate();
@@ -161,8 +162,8 @@ function Topbar({
                 type="search"
                 value={searchValue}
                 onChange={handleSearchInput}
-                placeholder="Buscar posts por título o etiqueta"
-                aria-label="Buscar posts"
+                placeholder={searchPlaceholder}
+                aria-label={searchPlaceholder}
                 className="w-full rounded-full border-slate-200 bg-white pl-10 pr-4 text-sm dark:border-slate-800 dark:bg-slate-900"
               />
               <span className="pointer-events-none absolute right-4 top-1/2 hidden -translate-y-1/2 rounded-full border border-slate-200 bg-white px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-slate-400 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-500 sm:inline-flex">
@@ -186,14 +187,16 @@ Topbar.propTypes = {
   onOpenMobile: PropTypes.func.isRequired,
   showSearch: PropTypes.bool,
   searchValue: PropTypes.string,
-  onSearchChange: PropTypes.func.isRequired
+  onSearchChange: PropTypes.func.isRequired,
+  searchPlaceholder: PropTypes.string
 };
 
 Topbar.defaultProps = {
   description: null,
   actions: null,
   showSearch: false,
-  searchValue: ''
+  searchValue: '',
+  searchPlaceholder: 'Buscar en el panel'
 };
 
 export default Topbar;

--- a/frontend/src/components/ui/textarea.jsx
+++ b/frontend/src/components/ui/textarea.jsx
@@ -1,0 +1,17 @@
+import { forwardRef } from 'react';
+import { cn } from '../../lib/utils';
+
+export const Textarea = forwardRef(({ className, ...props }, ref) => {
+  return (
+    <textarea
+      ref={ref}
+      className={cn(
+        'flex min-h-[120px] w-full rounded-2xl border border-slate-300 bg-white px-4 py-3 text-sm font-medium text-slate-700 shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:focus-visible:ring-offset-slate-950',
+        className
+      )}
+      {...props}
+    />
+  );
+});
+
+Textarea.displayName = 'Textarea';

--- a/frontend/src/pages/dashboard/DashboardCategories.jsx
+++ b/frontend/src/pages/dashboard/DashboardCategories.jsx
@@ -1,0 +1,372 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Modal, ToggleSwitch } from 'flowbite-react';
+import slugify from 'slugify';
+import { toast } from 'sonner';
+import { Pencil, Plus, Trash2 } from 'lucide-react';
+import { useDashboardLayout } from '../../layouts/DashboardLayout.jsx';
+import {
+  useDashboardStore,
+  selectCategoriesState
+} from '../../store/dashboard.js';
+import {
+  listCategories,
+  createCategory,
+  updateCategory,
+  deleteCategory
+} from '../../services/api.js';
+import { Button } from '../../components/ui/button.jsx';
+import { Input } from '../../components/ui/input.jsx';
+import { Textarea } from '../../components/ui/textarea.jsx';
+import ConfirmModal from '../../components/backoffice/ConfirmModal.jsx';
+
+const normalizeCollection = (payload) => {
+  if (Array.isArray(payload)) return payload;
+  if (payload?.results) return payload.results;
+  if (payload?.data) return payload.data;
+  return [];
+};
+
+const dedupeCategories = (categories) => {
+  const map = new Map();
+  categories.forEach((category) => {
+    if (!category) return;
+    const key = (category.slug ?? category.id ?? category.name ?? '').toString().toLowerCase();
+    if (!key) return;
+    if (!map.has(key)) {
+      map.set(key, { ...category });
+    } else {
+      const existing = map.get(key);
+      map.set(key, {
+        ...existing,
+        ...category,
+        post_count: Math.max(existing?.post_count ?? 0, category?.post_count ?? 0)
+      });
+    }
+  });
+  return Array.from(map.values()).sort((a, b) => (a.name ?? '').localeCompare(b.name ?? '', 'es'));
+};
+
+function DashboardCategories() {
+  const { setHeader } = useDashboardLayout();
+  const categoriesState = useDashboardStore(selectCategoriesState);
+  const setCategoriesSearch = useDashboardStore((state) => state.setCategoriesSearch);
+  const resetCategories = useDashboardStore((state) => state.resetCategories);
+
+  const [categories, setCategories] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [modalState, setModalState] = useState({
+    open: false,
+    mode: 'create',
+    slug: null,
+    name: '',
+    description: '',
+    isActive: true
+  });
+  const [deleteState, setDeleteState] = useState({ open: false, slug: null, name: '', loading: false });
+
+  useEffect(() => {
+    setHeader({
+      title: 'Categorías',
+      description: 'Crea y administra las categorías disponibles para el contenido.',
+      showSearch: false,
+      actions: (
+        <Button
+          type="button"
+          size="sm"
+          onClick={() => setModalState({ open: true, mode: 'create', slug: null, name: '', description: '', isActive: true })}
+        >
+          <Plus className="mr-2 h-4 w-4" aria-hidden="true" />
+          Nueva categoría
+        </Button>
+      )
+    });
+  }, [setHeader]);
+
+  useEffect(() => {
+    const fetchCategories = async () => {
+      setIsLoading(true);
+      try {
+        const response = await listCategories({ withCounts: true });
+        const normalized = normalizeCollection(response);
+        setCategories(dedupeCategories(normalized));
+      } catch (error) {
+        toast.error('No pudimos cargar las categorías, intenta de nuevo.');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchCategories();
+  }, []);
+
+  const filteredCategories = useMemo(() => {
+    const searchTerm = categoriesState.search.trim().toLowerCase();
+    if (!searchTerm) {
+      return categories;
+    }
+    return categories.filter((category) => category.name?.toLowerCase().includes(searchTerm));
+  }, [categories, categoriesState.search]);
+
+  const openEditModal = (category) => {
+    setModalState({
+      open: true,
+      mode: 'edit',
+      slug: category.slug,
+      name: category.name ?? '',
+      description: category.description ?? '',
+      isActive: category.is_active !== false
+    });
+  };
+
+  const closeModal = () => {
+    setModalState({ open: false, mode: 'create', slug: null, name: '', description: '', isActive: true });
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    const name = modalState.name.trim();
+    if (!name) {
+      toast.error('El nombre de la categoría es obligatorio.');
+      return;
+    }
+    const duplicate = categories.some((category) => {
+      if (!category?.name) return false;
+      const sameName = category.name.toLowerCase() === name.toLowerCase();
+      if (!sameName) return false;
+      if (modalState.mode === 'edit') {
+        return category.slug !== modalState.slug;
+      }
+      return true;
+    });
+
+    if (duplicate) {
+      toast.error('Ya existe una categoría con ese nombre.');
+      return;
+    }
+
+    const payload = {
+      name,
+      description: modalState.description.trim(),
+      is_active: modalState.isActive
+    };
+
+    try {
+      if (modalState.mode === 'edit' && modalState.slug) {
+        const updated = await updateCategory(modalState.slug, payload);
+        setCategories((prev) =>
+          dedupeCategories(
+            prev.map((category) =>
+              category.slug === modalState.slug
+                ? {
+                    ...category,
+                    ...updated,
+                    name: payload.name,
+                    description: payload.description,
+                    is_active: payload.is_active
+                  }
+                : category
+            )
+          )
+        );
+        toast.success('Categoría actualizada.');
+      } else {
+        const created = await createCategory(payload);
+        setCategories((prev) => dedupeCategories([created, ...prev]));
+        toast.success('Categoría creada.');
+      }
+      closeModal();
+    } catch (error) {
+      toast.error(error?.message ?? 'No se pudo guardar la categoría.');
+    }
+  };
+
+  const confirmDelete = async () => {
+    if (!deleteState.slug) {
+      return;
+    }
+    setDeleteState((prev) => ({ ...prev, loading: true }));
+    try {
+      await deleteCategory(deleteState.slug);
+      setCategories((prev) => dedupeCategories(prev.filter((category) => category.slug !== deleteState.slug)));
+      toast.success('Categoría eliminada.');
+    } catch (error) {
+      toast.error(error?.message ?? 'No se pudo eliminar la categoría.');
+    } finally {
+      setDeleteState({ open: false, slug: null, name: '', loading: false });
+    }
+  };
+
+  const computedSlug = useMemo(() => {
+    if (modalState.mode === 'edit') {
+      return modalState.slug ?? '';
+    }
+    return slugify(modalState.name || '', { lower: true, strict: true });
+  }, [modalState.mode, modalState.name, modalState.slug]);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-3 rounded-3xl border border-slate-200/70 bg-white/80 p-6 shadow-sm backdrop-blur dark:border-slate-800/70 dark:bg-slate-900/70">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <label className="flex flex-col gap-1 text-sm text-slate-500 dark:text-slate-400">
+            <span className="text-xs font-semibold uppercase tracking-wide text-slate-400">Buscar categoría</span>
+            <Input
+              type="search"
+              value={categoriesState.search}
+              onChange={(event) => setCategoriesSearch(event.target.value)}
+              placeholder="Filtra por nombre"
+              aria-label="Buscar categoría"
+            />
+          </label>
+          <Button type="button" variant="ghost" size="sm" onClick={resetCategories}>
+            Restablecer filtros
+          </Button>
+        </div>
+        <div className="overflow-hidden rounded-3xl border border-slate-200/70 dark:border-slate-800/70">
+          <table className="min-w-full divide-y divide-slate-200 dark:divide-slate-800">
+            <thead className="bg-slate-50/80 dark:bg-slate-900/70">
+              <tr>
+                <th scope="col" className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-400">
+                  Nombre
+                </th>
+                <th scope="col" className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-400">
+                  Slug
+                </th>
+                <th scope="col" className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-400">
+                  Estado
+                </th>
+                <th scope="col" className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-400">
+                  Posts asociados
+                </th>
+                <th scope="col" className="px-6 py-3 text-right text-xs font-semibold uppercase tracking-wide text-slate-400">
+                  Acciones
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-200 bg-white dark:divide-slate-800 dark:bg-slate-950/30">
+              {isLoading ? (
+                <tr>
+                  <td colSpan={5} className="px-6 py-16 text-center text-sm text-slate-500 dark:text-slate-400">
+                    Cargando categorías...
+                  </td>
+                </tr>
+              ) : filteredCategories.length === 0 ? (
+                <tr>
+                  <td colSpan={5} className="px-6 py-16 text-center text-sm text-slate-500 dark:text-slate-400">
+                    No se encontraron categorías con los criterios indicados.
+                  </td>
+                </tr>
+              ) : (
+                filteredCategories.map((category) => (
+                  <tr key={category.slug ?? category.name}>
+                    <td className="px-6 py-3 text-sm font-semibold text-slate-700 dark:text-slate-100">{category.name}</td>
+                    <td className="px-6 py-3 text-sm text-slate-500 dark:text-slate-400">{category.slug}</td>
+                    <td className="px-6 py-3 text-sm">
+                      <span
+                        className={`inline-flex items-center rounded-full px-2 py-1 text-xs font-semibold uppercase tracking-wide ${
+                          category.is_active !== false
+                            ? 'bg-emerald-500/10 text-emerald-600 dark:bg-emerald-500/20 dark:text-emerald-300'
+                            : 'bg-amber-500/10 text-amber-600 dark:bg-amber-500/20 dark:text-amber-300'
+                        }`}
+                      >
+                        {category.is_active !== false ? 'Activa' : 'Inactiva'}
+                      </span>
+                    </td>
+                    <td className="px-6 py-3 text-sm text-slate-500 dark:text-slate-400">{category.post_count ?? 0}</td>
+                    <td className="px-6 py-3 text-right">
+                      <div className="flex items-center justify-end gap-2">
+                        <Button type="button" size="icon" variant="ghost" onClick={() => openEditModal(category)} aria-label={`Editar ${category.name}`}>
+                          <Pencil className="h-4 w-4" aria-hidden="true" />
+                        </Button>
+                        <Button
+                          type="button"
+                          size="icon"
+                          variant="ghost"
+                          className="text-red-500 hover:text-red-600 dark:text-red-400 dark:hover:text-red-300"
+                          onClick={() => setDeleteState({ open: true, slug: category.slug, name: category.name, loading: false })}
+                          aria-label={`Eliminar ${category.name}`}
+                        >
+                          <Trash2 className="h-4 w-4" aria-hidden="true" />
+                        </Button>
+                      </div>
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+        <p className="text-xs text-slate-500 dark:text-slate-400">
+          {filteredCategories.length} categoría(s) de {categories.length} disponibles.
+        </p>
+      </div>
+
+      <Modal
+        show={modalState.open}
+        size="lg"
+        onClose={closeModal}
+        aria-labelledby="category-modal-title"
+      >
+        <Modal.Header>
+          <h2 id="category-modal-title" className="text-lg font-semibold text-slate-900 dark:text-white">
+            {modalState.mode === 'edit' ? 'Editar categoría' : 'Nueva categoría'}
+          </h2>
+        </Modal.Header>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <Modal.Body className="space-y-4">
+            <label className="flex flex-col gap-1 text-sm text-slate-500 dark:text-slate-400" htmlFor="category-name">
+              Nombre de la categoría
+              <Input
+                id="category-name"
+                value={modalState.name}
+                onChange={(event) => setModalState((prev) => ({ ...prev, name: event.target.value }))}
+                placeholder="Nombre de la categoría"
+                aria-describedby="category-slug-preview"
+                autoFocus
+              />
+            </label>
+            <p id="category-slug-preview" className="text-xs text-slate-500 dark:text-slate-400">
+              Slug previsto: {computedSlug || '—'}
+            </p>
+            <label className="flex items-center justify-between rounded-2xl border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-600 shadow-sm dark:border-slate-800 dark:bg-slate-900 dark:text-slate-300">
+              <span>¿Categoría activa?</span>
+              <ToggleSwitch
+                checked={modalState.isActive}
+                label=""
+                onChange={(checked) => setModalState((prev) => ({ ...prev, isActive: checked }))}
+              />
+            </label>
+            <label className="flex flex-col gap-1 text-sm text-slate-500 dark:text-slate-400" htmlFor="category-description">
+              Descripción
+              <Textarea
+                id="category-description"
+                value={modalState.description}
+                onChange={(event) => setModalState((prev) => ({ ...prev, description: event.target.value }))}
+                rows={4}
+                placeholder="Descripción opcional de la categoría"
+              />
+              <span className="text-xs text-slate-400 dark:text-slate-500">Esta información ayuda a tu equipo a reutilizar la categoría correctamente.</span>
+            </label>
+          </Modal.Body>
+          <Modal.Footer className="flex items-center justify-end gap-2">
+            <Button type="button" variant="ghost" onClick={closeModal}>
+              Cancelar
+            </Button>
+            <Button type="submit">{modalState.mode === 'edit' ? 'Guardar cambios' : 'Crear categoría'}</Button>
+          </Modal.Footer>
+        </form>
+      </Modal>
+
+      <ConfirmModal
+        open={deleteState.open}
+        title="¿Eliminar categoría?"
+        description={deleteState.name ? `Se eliminará "${deleteState.name}" del listado.` : null}
+        onCancel={() => setDeleteState({ open: false, slug: null, name: '', loading: false })}
+        onConfirm={confirmDelete}
+        tone="danger"
+        loading={deleteState.loading}
+      />
+    </div>
+  );
+}
+
+export default DashboardCategories;

--- a/frontend/src/pages/dashboard/DashboardComments.jsx
+++ b/frontend/src/pages/dashboard/DashboardComments.jsx
@@ -1,32 +1,297 @@
-import { useEffect } from 'react';
-import { MessageSquare } from 'lucide-react';
-import EmptyState from '../../components/backoffice/EmptyState.jsx';
-import { useDashboardLayout } from '../../layouts/DashboardLayout.jsx';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { toast } from 'sonner';
+import { Trash2 } from 'lucide-react';
+import DataTable from '../../components/backoffice/DataTable.jsx';
+import ConfirmModal from '../../components/backoffice/ConfirmModal.jsx';
 import { Button } from '../../components/ui/button.jsx';
+import { Input } from '../../components/ui/input.jsx';
+import { useDashboardLayout } from '../../layouts/DashboardLayout.jsx';
+import {
+  useDashboardStore,
+  selectCommentsState
+} from '../../store/dashboard.js';
+import { listPosts, listComments, deleteComment } from '../../services/api.js';
+
+const truncate = (value, length = 80) => {
+  if (!value) return '';
+  if (value.length <= length) return value;
+  return `${value.slice(0, length).trim()}…`;
+};
 
 function DashboardComments() {
   const { setHeader } = useDashboardLayout();
+  const commentsState = useDashboardStore(selectCommentsState);
+  const setCommentsFilters = useDashboardStore((state) => state.setCommentsFilters);
+  const resetComments = useDashboardStore((state) => state.resetComments);
+
+  const [posts, setPosts] = useState([]);
+  const [comments, setComments] = useState([]);
+  const [totalCount, setTotalCount] = useState(0);
+  const [pageCount, setPageCount] = useState(1);
+  const [isLoading, setIsLoading] = useState(true);
+  const [deleteState, setDeleteState] = useState({ open: false, id: null, loading: false, preview: '' });
+
+  const fetchPosts = useCallback(async () => {
+    try {
+      const response = await listPosts({ pageSize: 50, ordering: '-date' });
+      const normalized = Array.isArray(response?.results) ? response.results : [];
+      const unique = new Map();
+      normalized.forEach((post) => {
+        if (!post?.slug) return;
+        if (!unique.has(post.slug)) {
+          unique.set(post.slug, { slug: post.slug, title: post.title ?? post.slug });
+        }
+      });
+      setPosts(Array.from(unique.values()));
+    } catch (error) {
+      toast.error('No pudimos cargar el listado de posts.');
+    }
+  }, []);
+
+  const fetchComments = useCallback(async () => {
+    if (!commentsState.postSlug) {
+      setComments([]);
+      setTotalCount(0);
+      setPageCount(1);
+      setIsLoading(false);
+      return;
+    }
+    setIsLoading(true);
+    try {
+      const response = await listComments(commentsState.postSlug, {
+        page: commentsState.page,
+        pageSize: commentsState.pageSize,
+        ordering: commentsState.ordering
+      });
+      const results = Array.isArray(response?.results) ? response.results : [];
+      const count = typeof response?.count === 'number' ? response.count : results.length;
+      setComments(results);
+      setTotalCount(count);
+      setPageCount(Math.max(Math.ceil(count / commentsState.pageSize), 1));
+    } catch (error) {
+      toast.error('No pudimos cargar los comentarios.');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [commentsState.ordering, commentsState.page, commentsState.pageSize, commentsState.postSlug]);
 
   useEffect(() => {
     setHeader({
       title: 'Comentarios',
       description: 'Modera la conversación y coordina respuestas con el equipo.',
       showSearch: false,
-      actions: null
+      actions: (
+        <Button type="button" size="sm" onClick={fetchComments} disabled={!commentsState.postSlug}>
+          Recargar
+        </Button>
+      )
     });
-  }, [setHeader]);
+  }, [commentsState.postSlug, fetchComments, setHeader]);
+
+  useEffect(() => {
+    fetchPosts();
+  }, [fetchPosts]);
+
+  useEffect(() => {
+    fetchComments();
+  }, [fetchComments]);
+
+  const filteredComments = useMemo(() => {
+    const searchTerm = commentsState.search.trim().toLowerCase();
+    if (!searchTerm) {
+      return comments;
+    }
+    return comments.filter((comment) =>
+      `${comment.author_name ?? ''} ${comment.content ?? ''}`.toLowerCase().includes(searchTerm)
+    );
+  }, [comments, commentsState.search]);
+
+  const columns = useMemo(
+    () => [
+      {
+        accessorKey: 'author_name',
+        enableSorting: false,
+        header: () => <span className="text-xs font-semibold uppercase tracking-wide text-slate-400">Autor</span>,
+        cell: ({ row }) => (
+          <div className="max-w-[12rem]">
+            <p className="font-medium text-slate-800 dark:text-slate-100">{row.original.author_name}</p>
+            <p className="text-xs text-slate-500 dark:text-slate-400">{row.original.email ?? 'Sin correo'}</p>
+          </div>
+        )
+      },
+      {
+        accessorKey: 'content',
+        enableSorting: false,
+        header: () => <span className="text-xs font-semibold uppercase tracking-wide text-slate-400">Comentario</span>,
+        cell: ({ row }) => (
+          <p className="max-w-xl text-sm text-slate-600 dark:text-slate-300">{truncate(row.original.content)}</p>
+        )
+      },
+      {
+        accessorKey: 'created_at',
+        enableSorting: false,
+        header: () => <span className="text-xs font-semibold uppercase tracking-wide text-slate-400">Fecha</span>,
+        cell: ({ row }) => {
+          const date = new Date(row.original.created_at);
+          if (Number.isNaN(date.getTime())) {
+            return <span className="text-xs text-slate-400">Sin fecha</span>;
+          }
+          return (
+            <span className="text-xs text-slate-500 dark:text-slate-400">
+              {new Intl.DateTimeFormat('es-ES', {
+                day: '2-digit',
+                month: 'short',
+                year: 'numeric',
+                hour: '2-digit',
+                minute: '2-digit'
+              })
+                .format(date)
+                .replace('.', '')}
+            </span>
+          );
+        }
+      },
+      {
+        id: 'actions',
+        enableSorting: false,
+        header: () => <span className="sr-only">Acciones</span>,
+        cell: ({ row }) => (
+          <div className="flex items-center justify-end">
+            <Button
+              type="button"
+              size="icon"
+              variant="ghost"
+              className="text-red-500 hover:text-red-600 dark:text-red-400 dark:hover:text-red-300"
+              onClick={() =>
+                setDeleteState({
+                  open: true,
+                  id: row.original.id,
+                  loading: false,
+                  preview: truncate(row.original.content, 120)
+                })
+              }
+              aria-label={`Eliminar comentario de ${row.original.author_name ?? 'usuario'}`}
+            >
+              <Trash2 className="h-4 w-4" aria-hidden="true" />
+            </Button>
+          </div>
+        )
+      }
+    ],
+    []
+  );
+
+  const confirmDelete = useCallback(async () => {
+    if (!deleteState.id) {
+      return;
+    }
+    setDeleteState((prev) => ({ ...prev, loading: true }));
+    try {
+      await deleteComment(deleteState.id);
+      toast.success('Comentario eliminado.');
+      setDeleteState({ open: false, id: null, loading: false, preview: '' });
+      fetchComments();
+    } catch (error) {
+      if (error?.status === 405) {
+        toast.info('El backend aún no permite eliminar comentarios desde el panel.');
+      } else {
+        toast.error(error?.message ?? 'No se pudo eliminar el comentario.');
+      }
+      setDeleteState({ open: false, id: null, loading: false, preview: '' });
+    }
+  }, [deleteState.id, fetchComments]);
+
+  const pageIndex = commentsState.page - 1;
 
   return (
-    <EmptyState
-      icon={MessageSquare}
-      title="Moderación en camino"
-      description="Aquí verás las colas de moderación, respuestas pendientes y métricas de participación cuando conectemos la API de comentarios."
-      action={
-        <Button type="button" variant="ghost" size="sm" onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}>
-          Volver al resumen
-        </Button>
-      }
-    />
+    <div className="space-y-6">
+      <div className="flex flex-col gap-3 rounded-3xl border border-slate-200/70 bg-white/80 p-6 shadow-sm backdrop-blur dark:border-slate-800/70 dark:bg-slate-900/70">
+        <div className="grid gap-4 lg:grid-cols-4">
+          <label className="flex flex-col gap-1 text-sm text-slate-500 dark:text-slate-400">
+            <span className="text-xs font-semibold uppercase tracking-wide text-slate-400">Selecciona un post</span>
+            <select
+              value={commentsState.postSlug ?? ''}
+              onChange={(event) =>
+                setCommentsFilters({ postSlug: event.target.value, page: 1 })
+              }
+              className="w-full rounded-2xl border border-slate-200 bg-white px-4 py-2 text-sm text-slate-600 shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-200"
+            >
+              <option value="">Selecciona un post para ver sus comentarios</option>
+              {posts.map((post) => (
+                <option key={post.slug} value={post.slug}>
+                  {post.title}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex flex-col gap-1 text-sm text-slate-500 dark:text-slate-400">
+            <span className="text-xs font-semibold uppercase tracking-wide text-slate-400">Buscar</span>
+            <Input
+              type="search"
+              value={commentsState.search}
+              onChange={(event) => setCommentsFilters({ search: event.target.value, page: 1 })}
+              placeholder="Filtra por autor o contenido"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm text-slate-500 dark:text-slate-400">
+            <span className="text-xs font-semibold uppercase tracking-wide text-slate-400">Ordenar</span>
+            <select
+              value={commentsState.ordering}
+              onChange={(event) => setCommentsFilters({ ordering: event.target.value })}
+              className="w-full rounded-2xl border border-slate-200 bg-white px-4 py-2 text-sm text-slate-600 shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-200"
+            >
+              <option value="-created_at">Más recientes</option>
+              <option value="created_at">Más antiguos</option>
+            </select>
+          </label>
+          <div className="flex items-end">
+            <Button type="button" variant="ghost" size="sm" onClick={resetComments}>
+              Restablecer filtros
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      {commentsState.postSlug ? (
+        <DataTable
+          columns={columns}
+          data={filteredComments}
+          isLoading={isLoading}
+          pageIndex={pageIndex}
+          pageSize={commentsState.pageSize}
+          pageCount={pageCount}
+          onPageChange={(nextIndex) =>
+            setCommentsFilters({ page: nextIndex + 1 })
+          }
+          renderToolbar={null}
+          loadingMessage="Cargando comentarios..."
+          emptyState={{
+            title: 'Sin comentarios registrados',
+            description: 'Cuando haya comentarios aparecerán aquí para su moderación.'
+          }}
+        />
+      ) : (
+        <div className="rounded-3xl border border-dashed border-slate-300/70 bg-white/80 p-6 text-center text-sm text-slate-500 shadow-sm dark:border-slate-700/70 dark:bg-slate-900/70 dark:text-slate-400">
+          Selecciona un post del listado para revisar sus comentarios.
+        </div>
+      )}
+
+      <ConfirmModal
+        open={deleteState.open}
+        title="¿Eliminar comentario?"
+        description={deleteState.preview ? `Se eliminará el comentario: "${deleteState.preview}"` : 'Esta acción eliminará el comentario del sistema.'}
+        onCancel={() => setDeleteState({ open: false, id: null, loading: false, preview: '' })}
+        onConfirm={confirmDelete}
+        tone="danger"
+        loading={deleteState.loading}
+      />
+
+      {commentsState.postSlug ? (
+        <p className="text-xs text-slate-500 dark:text-slate-400">
+          {filteredComments.length} comentario(s) mostrados de {totalCount} disponibles.
+        </p>
+      ) : null}
+    </div>
   );
 }
 

--- a/frontend/src/pages/dashboard/DashboardPostDetail.jsx
+++ b/frontend/src/pages/dashboard/DashboardPostDetail.jsx
@@ -1,0 +1,140 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import DOMPurify from 'dompurify';
+import { useDashboardLayout } from '../../layouts/DashboardLayout.jsx';
+import { getPost } from '../../services/api.js';
+import { Button } from '../../components/ui/button.jsx';
+
+function DashboardPostDetail() {
+  const { slug } = useParams();
+  const navigate = useNavigate();
+  const { setHeader } = useDashboardLayout();
+  const [post, setPost] = useState(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    setHeader({
+      title: 'Detalle del post',
+      description: 'Vista previa del contenido publicado.',
+      showSearch: false,
+      actions: (
+        <div className="flex items-center gap-2">
+          <Button type="button" variant="ghost" onClick={() => navigate('/dashboard/posts')}>
+            Volver al listado
+          </Button>
+          <Button type="button" onClick={() => navigate(`/dashboard/posts/${slug}/edit`)}>
+            Editar post
+          </Button>
+        </div>
+      )
+    });
+  }, [navigate, setHeader, slug]);
+
+  useEffect(() => {
+    const fetchPost = async () => {
+      if (!slug) {
+        navigate('/dashboard/posts', { replace: true });
+        return;
+      }
+      try {
+        const data = await getPost(slug);
+        setPost(data);
+      } catch (error) {
+        navigate('/dashboard/posts', { replace: true });
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchPost();
+  }, [navigate, slug]);
+
+  const formattedDate = useMemo(() => {
+    if (!post?.created_at) {
+      return 'Sin fecha';
+    }
+    const date = new Date(post.created_at);
+    if (Number.isNaN(date.getTime())) {
+      return 'Sin fecha';
+    }
+    return new Intl.DateTimeFormat('es-ES', {
+      day: '2-digit',
+      month: 'long',
+      year: 'numeric'
+    }).format(date);
+  }, [post?.created_at]);
+
+  const safeContent = useMemo(() => {
+    const raw = post?.content ?? '';
+    const sanitized = DOMPurify.sanitize(raw, { USE_PROFILES: { html: true } });
+    return sanitized || '<p>Sin contenido.</p>';
+  }, [post?.content]);
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-[40vh] items-center justify-center text-slate-500 dark:text-slate-400">
+        <span className="animate-pulse text-sm">Cargando post...</span>
+      </div>
+    );
+  }
+
+  if (!post) {
+    return (
+      <div className="rounded-3xl border border-slate-200/70 bg-white/80 p-6 text-sm text-slate-500 shadow-sm dark:border-slate-800/70 dark:bg-slate-900/70 dark:text-slate-400">
+        No encontramos la publicación solicitada.
+      </div>
+    );
+  }
+
+  return (
+    <article className="space-y-6 rounded-3xl border border-slate-200/70 bg-white/80 p-6 shadow-sm dark:border-slate-800/70 dark:bg-slate-900/70">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-semibold text-slate-900 dark:text-white">{post.title}</h1>
+        <p className="text-sm text-slate-500 dark:text-slate-400">
+          <span>{post.author ?? 'Autor desconocido'}</span>
+          <span className="mx-2">•</span>
+          <span>{formattedDate}</span>
+        </p>
+        <p className="text-base text-slate-600 dark:text-slate-300">{post.excerpt}</p>
+        <div className="flex flex-wrap items-center gap-2">
+          {Array.isArray(post.categories_detail) && post.categories_detail.length > 0 ? (
+            post.categories_detail.map((category) => (
+              <span
+                key={category.slug ?? category.name}
+                className="inline-flex items-center rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-600 dark:bg-slate-800/70 dark:text-slate-300"
+              >
+                {category.name ?? category.slug}
+              </span>
+            ))
+          ) : (
+            <span className="text-xs text-slate-400">Sin categorías</span>
+          )}
+        </div>
+      </header>
+      {post.image ? (
+        <img
+          src={post.image}
+          alt={post.imageAlt ?? 'Imagen del post'}
+          className="w-full rounded-3xl object-cover"
+        />
+      ) : null}
+      <section className="prose prose-slate max-w-none dark:prose-invert" dangerouslySetInnerHTML={{ __html: safeContent }} />
+      <footer className="flex flex-wrap items-center gap-2 text-sm text-slate-500 dark:text-slate-400">
+        {Array.isArray(post.tags) && post.tags.length > 0 ? (
+          post.tags.map((tag) => (
+            <span
+              key={tag}
+              className="inline-flex items-center rounded-full bg-sky-500/10 px-2 py-1 text-xs font-medium text-sky-600 dark:bg-sky-500/20 dark:text-sky-300"
+            >
+              #{tag}
+            </span>
+          ))
+        ) : (
+          <span className="text-xs text-slate-400">Sin etiquetas</span>
+        )}
+      </footer>
+    </article>
+  );
+}
+
+export default DashboardPostDetail;

--- a/frontend/src/pages/dashboard/DashboardPostEdit.jsx
+++ b/frontend/src/pages/dashboard/DashboardPostEdit.jsx
@@ -1,0 +1,40 @@
+import { useEffect } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useDashboardLayout } from '../../layouts/DashboardLayout.jsx';
+import PostForm from '../../components/backoffice/PostForm.jsx';
+
+function DashboardPostEdit() {
+  const { slug } = useParams();
+  const navigate = useNavigate();
+  const { setHeader } = useDashboardLayout();
+
+  useEffect(() => {
+    setHeader({
+      title: 'Editar post',
+      description: 'Actualiza los datos del post y controla su publicación.',
+      showSearch: false,
+      actions: null
+    });
+  }, [setHeader]);
+
+  useEffect(() => {
+    if (!slug) {
+      navigate('/dashboard/posts', { replace: true });
+    }
+  }, [navigate, slug]);
+
+  if (!slug) {
+    return null;
+  }
+
+  return (
+    <PostForm
+      mode="edit"
+      slug={slug}
+      onCancel={() => navigate('/dashboard/posts')}
+      onSuccess={() => navigate('/dashboard/posts')}
+    />
+  );
+}
+
+export default DashboardPostEdit;

--- a/frontend/src/pages/dashboard/DashboardPostNew.jsx
+++ b/frontend/src/pages/dashboard/DashboardPostNew.jsx
@@ -1,0 +1,28 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useDashboardLayout } from '../../layouts/DashboardLayout.jsx';
+import PostForm from '../../components/backoffice/PostForm.jsx';
+
+function DashboardPostNew() {
+  const { setHeader } = useDashboardLayout();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    setHeader({
+      title: 'Nuevo post',
+      description: 'Completa los campos para crear una nueva publicación.',
+      showSearch: false,
+      actions: null
+    });
+  }, [setHeader]);
+
+  return (
+    <PostForm
+      mode="create"
+      onCancel={() => navigate('/dashboard/posts')}
+      onSuccess={() => navigate('/dashboard/posts')}
+    />
+  );
+}
+
+export default DashboardPostNew;

--- a/frontend/src/pages/dashboard/DashboardPosts.jsx
+++ b/frontend/src/pages/dashboard/DashboardPosts.jsx
@@ -1,114 +1,552 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import Select from 'react-select';
 import { toast } from 'sonner';
-import { RefreshCcw, Plus } from 'lucide-react';
+import { Eye, Pencil, Trash2, Plus } from 'lucide-react';
 import DataTable from '../../components/backoffice/DataTable.jsx';
 import ConfirmModal from '../../components/backoffice/ConfirmModal.jsx';
 import { Button } from '../../components/ui/button.jsx';
-import { getPosts, deletePost } from '../../services/api.js';
 import { useDashboardLayout } from '../../layouts/DashboardLayout.jsx';
+import {
+  useDashboardStore,
+  selectPostsState
+} from '../../store/dashboard.js';
+import {
+  listPosts,
+  deletePost,
+  listCategories,
+  listTags
+} from '../../services/api.js';
+
+const STATUS_OPTIONS = [
+  { value: 'all', label: 'Todos' },
+  { value: 'published', label: 'Publicados' },
+  { value: 'scheduled', label: 'Programados' }
+];
+
+const ORDER_OPTIONS = [
+  { value: '-date', label: 'Más recientes' },
+  { value: 'date', label: 'Más antiguos' },
+  { value: '-title', label: 'Título Z-A' },
+  { value: 'title', label: 'Título A-Z' }
+];
+
+const normalizeCollection = (payload) => {
+  if (Array.isArray(payload)) return payload;
+  if (payload?.results) return payload.results;
+  if (payload?.data) return payload.data;
+  return [];
+};
+
+const statusBadgeClass = {
+  published:
+    'inline-flex items-center rounded-full bg-emerald-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-emerald-600 dark:bg-emerald-500/20 dark:text-emerald-300',
+  scheduled:
+    'inline-flex items-center rounded-full bg-sky-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-sky-600 dark:bg-sky-500/20 dark:text-sky-300'
+};
+
+const createTagSelectStyles = (isDarkMode) => ({
+  control: (provided, state) => ({
+    ...provided,
+    backgroundColor: isDarkMode ? 'rgba(15,23,42,0.75)' : 'rgba(255,255,255,0.95)',
+    borderColor: state.isFocused
+      ? 'rgb(14 165 233 / 0.8)'
+      : isDarkMode
+        ? 'rgba(71, 85, 105, 0.8)'
+        : 'rgb(226 232 240)',
+    boxShadow: state.isFocused ? '0 0 0 2px rgb(14 165 233 / 0.25)' : 'none',
+    borderWidth: '1px',
+    minHeight: '44px'
+  }),
+  multiValue: (provided) => ({
+    ...provided,
+    backgroundColor: isDarkMode ? 'rgba(56,189,248,0.25)' : 'rgb(14 165 233 / 0.15)',
+    color: isDarkMode ? 'rgb(125 211 252)' : 'rgb(14 116 144)'
+  }),
+  multiValueLabel: (provided) => ({
+    ...provided,
+    color: isDarkMode ? 'rgb(191 219 254)' : provided.color
+  }),
+  option: (provided, state) => ({
+    ...provided,
+    backgroundColor: state.isSelected
+      ? 'rgb(14 165 233 / 0.25)'
+      : state.isFocused
+        ? 'rgb(14 165 233 / 0.15)'
+        : isDarkMode
+          ? 'rgba(15,23,42,0.95)'
+          : 'white',
+    color: isDarkMode ? 'rgb(226 232 240)' : 'rgb(15 23 42)'
+  }),
+  menu: (provided) => ({
+    ...provided,
+    backgroundColor: isDarkMode ? 'rgba(15,23,42,0.95)' : 'white',
+    zIndex: 30
+  }),
+  input: (provided) => ({
+    ...provided,
+    color: isDarkMode ? 'rgb(226 232 240)' : 'rgb(15 23 42)'
+  }),
+  placeholder: (provided) => ({
+    ...provided,
+    color: isDarkMode ? 'rgb(148 163 184)' : 'rgb(100 116 139)'
+  }),
+  singleValue: (provided) => ({
+    ...provided,
+    color: isDarkMode ? 'rgb(226 232 240)' : 'rgb(15 23 42)'
+  })
+});
 
 function DashboardPosts() {
+  const navigate = useNavigate();
   const { setHeader } = useDashboardLayout();
+  const postsState = useDashboardStore(selectPostsState);
+  const setPostsStatus = useDashboardStore((state) => state.setPostsStatus);
+  const setPostsOrdering = useDashboardStore((state) => state.setPostsOrdering);
+  const setPostsPagination = useDashboardStore((state) => state.setPostsPagination);
+  const setPostsCategory = useDashboardStore((state) => state.setPostsCategory);
+  const setPostsTags = useDashboardStore((state) => state.setPostsTags);
+  const resetPosts = useDashboardStore((state) => state.resetPosts);
+
   const [posts, setPosts] = useState([]);
+  const [totalCount, setTotalCount] = useState(0);
+  const [pageCount, setPageCount] = useState(1);
   const [isLoading, setIsLoading] = useState(true);
-  const [confirmState, setConfirmState] = useState({ open: false, post: null, isDeleting: false });
+  const [confirmState, setConfirmState] = useState({ open: false, slug: null, title: '', loading: false });
+  const [categories, setCategories] = useState([]);
+  const [tags, setTags] = useState([]);
+
+  const isDarkMode = useMemo(
+    () => (typeof document !== 'undefined' ? document.documentElement.classList.contains('dark') : false),
+    []
+  );
+  const tagSelectStyles = useMemo(() => createTagSelectStyles(isDarkMode), [isDarkMode]);
+
+  const fetchFilters = useCallback(async () => {
+    try {
+      const [categoriesResponse, tagsResponse] = await Promise.all([
+        listCategories({ withCounts: true }),
+        listTags()
+      ]);
+      const normalizedCategories = normalizeCollection(categoriesResponse).map((category) => ({
+        value: category.slug ?? category.id,
+        label: category.name ?? category.title ?? 'Sin nombre'
+      }));
+      setCategories(normalizedCategories);
+
+      const normalizedTags = normalizeCollection(tagsResponse).map((tag) => {
+        const name = tag.name ?? tag.slug ?? String(tag);
+        return {
+          value: name,
+          label: tag.usage ? `${name} (${tag.usage})` : name
+        };
+      });
+      setTags(normalizedTags);
+    } catch (error) {
+      toast.error('No fue posible cargar categorías y etiquetas.');
+    }
+  }, []);
 
   const fetchPosts = useCallback(async () => {
     setIsLoading(true);
     try {
-      const response = await getPosts();
-      setPosts(response.results ?? []);
+      const response = await listPosts({
+        page: postsState.page,
+        pageSize: postsState.pageSize,
+        search: postsState.search,
+        ordering: postsState.ordering,
+        category: postsState.category || undefined,
+        tags: postsState.tags,
+        status: postsState.status
+      });
+      const results = Array.isArray(response?.results) ? response.results : [];
+      const count = typeof response?.count === 'number' ? response.count : results.length;
+      setPosts(results);
+      setTotalCount(count);
+      setPageCount(Math.max(Math.ceil(count / postsState.pageSize), 1));
     } catch (error) {
-      console.error('No fue posible obtener los posts del dashboard.', error);
       toast.error('No pudimos cargar los posts, intenta de nuevo.');
     } finally {
       setIsLoading(false);
     }
-  }, []);
+  }, [postsState.category, postsState.ordering, postsState.page, postsState.pageSize, postsState.search, postsState.status, postsState.tags]);
+
+  useEffect(() => {
+    fetchFilters();
+  }, [fetchFilters]);
 
   useEffect(() => {
     fetchPosts();
   }, [fetchPosts]);
+
+  const handleCreate = useCallback(() => {
+    navigate('/dashboard/posts/new');
+  }, [navigate]);
 
   const handleRefresh = useCallback(() => {
     toast.info('Actualizando listado de posts...');
     fetchPosts();
   }, [fetchPosts]);
 
-  const handleCreate = useCallback(() => {
-    toast.info('La creación de posts llegará cuando se conecte el backend.');
-  }, []);
-
   useEffect(() => {
     setHeader({
       title: 'Posts',
       description: 'Gestiona el estado de las publicaciones y revisa su actividad.',
       showSearch: true,
+      searchPlaceholder: 'Buscar posts por título, tag o categoría',
       actions: (
         <div className="flex items-center gap-2">
-          <Button type="button" size="sm" variant="secondary" onClick={handleCreate}>
-            <Plus className="h-4 w-4" aria-hidden="true" />
+          <Button type="button" size="sm" onClick={handleCreate}>
+            <Plus className="mr-2 h-4 w-4" aria-hidden="true" />
             Nuevo post
           </Button>
           <Button type="button" size="sm" variant="ghost" onClick={handleRefresh}>
-            <RefreshCcw className="h-4 w-4" aria-hidden="true" />
-            Refrescar
+            Recargar
           </Button>
         </div>
       )
     });
   }, [handleCreate, handleRefresh, setHeader]);
 
-  const handleView = useCallback((post) => {
-    toast.info(`Vista previa de "${post.title}" disponible próximamente.`);
-  }, []);
+  const handleView = useCallback(
+    (post) => {
+      navigate(`/dashboard/posts/${post.slug}`);
+    },
+    [navigate]
+  );
 
-  const handleEdit = useCallback((post) => {
-    toast.info(`La edición de "${post.title}" se habilitará cuando conectemos el CMS.`);
-  }, []);
+  const handleEdit = useCallback(
+    (post) => {
+      navigate(`/dashboard/posts/${post.slug}/edit`);
+    },
+    [navigate]
+  );
 
   const handleDelete = useCallback((post) => {
-    setConfirmState({ open: true, post, isDeleting: false });
+    setConfirmState({ open: true, slug: post.slug, title: post.title, loading: false });
   }, []);
 
   const confirmDelete = useCallback(async () => {
-    if (!confirmState.post) {
+    if (!confirmState.slug) {
       return;
     }
-    setConfirmState((state) => ({ ...state, isDeleting: true }));
+    setConfirmState((prev) => ({ ...prev, loading: true }));
     try {
-      await deletePost(confirmState.post.id);
-      setPosts((current) => current.filter((item) => item.id !== confirmState.post.id));
-      toast.success(`Post "${confirmState.post.title}" eliminado.`);
+      await deletePost(confirmState.slug);
+      toast.success('El post se eliminó correctamente.');
+      setConfirmState({ open: false, slug: null, title: '', loading: false });
+      fetchPosts();
     } catch (error) {
-      console.error('No se pudo eliminar el post.', error);
-      toast.error('No se pudo eliminar el post, intenta de nuevo.');
-    } finally {
-      setConfirmState({ open: false, post: null, isDeleting: false });
+      toast.error(error?.message ?? 'No se pudo eliminar el post.');
+      setConfirmState({ open: false, slug: null, title: '', loading: false });
     }
-  }, [confirmState.post]);
+  }, [confirmState.slug, fetchPosts]);
 
-  const modalDescription = useMemo(() => {
-    if (!confirmState.post) {
-      return null;
+  const pageIndex = postsState.page - 1;
+
+  const columns = useMemo(
+    () => [
+      {
+        accessorKey: 'title',
+        enableSorting: false,
+        header: () => <span className="text-xs font-semibold uppercase tracking-wide text-slate-400">Título</span>,
+        cell: ({ row }) => {
+          const original = row.original;
+          return (
+            <div className="max-w-xs space-y-1">
+              <p className="font-semibold text-slate-900 dark:text-white">{original.title}</p>
+              <p className="text-xs text-slate-500 dark:text-slate-400">{original.excerpt}</p>
+            </div>
+          );
+        }
+      },
+      {
+        accessorKey: 'status',
+        enableSorting: false,
+        header: () => <span className="text-xs font-semibold uppercase tracking-wide text-slate-400">Estado</span>,
+        cell: ({ row }) => {
+          const { status } = row.original;
+          const badgeClass = statusBadgeClass[status] ?? statusBadgeClass.published;
+          const label = status === 'scheduled' ? 'Programado' : 'Publicado';
+          return <span className={badgeClass}>{label}</span>;
+        }
+      },
+      {
+        accessorKey: 'categories',
+        enableSorting: false,
+        header: () => <span className="text-xs font-semibold uppercase tracking-wide text-slate-400">Categorías</span>,
+        cell: ({ row }) => {
+          const categoriesDetail = Array.isArray(row.original.categories_detail)
+            ? row.original.categories_detail
+            : [];
+          if (categoriesDetail.length === 0) {
+            return <span className="text-xs text-slate-400">Sin categoría</span>;
+          }
+          return (
+            <div className="flex flex-wrap items-center gap-1">
+              {categoriesDetail.slice(0, 2).map((category) => (
+                <span
+                  key={category.slug ?? category.name}
+                  className="inline-flex items-center rounded-full bg-slate-100 px-2 py-1 text-[11px] font-medium text-slate-600 dark:bg-slate-800/70 dark:text-slate-300"
+                >
+                  {category.name ?? category.slug}
+                </span>
+              ))}
+              {categoriesDetail.length > 2 ? (
+                <span className="text-xs text-slate-400">+{categoriesDetail.length - 2}</span>
+              ) : null}
+            </div>
+          );
+        }
+      },
+      {
+        accessorKey: 'tags',
+        enableSorting: false,
+        header: () => <span className="text-xs font-semibold uppercase tracking-wide text-slate-400">Etiquetas</span>,
+        cell: ({ row }) => {
+          const tagsList = Array.isArray(row.original.tags) ? row.original.tags : [];
+          if (tagsList.length === 0) {
+            return <span className="text-xs text-slate-400">Sin tags</span>;
+          }
+          return (
+            <div className="flex flex-wrap items-center gap-1">
+              {tagsList.slice(0, 3).map((tag) => (
+                <span
+                  key={tag}
+                  className="inline-flex items-center rounded-full bg-sky-500/10 px-2 py-1 text-[11px] font-medium text-sky-600 dark:bg-sky-500/20 dark:text-sky-300"
+                >
+                  #{tag}
+                </span>
+              ))}
+              {tagsList.length > 3 ? (
+                <span className="text-xs text-slate-400">+{tagsList.length - 3}</span>
+              ) : null}
+            </div>
+          );
+        }
+      },
+      {
+        accessorKey: 'created_at',
+        enableSorting: false,
+        header: () => <span className="text-xs font-semibold uppercase tracking-wide text-slate-400">Fecha</span>,
+        cell: ({ row }) => {
+          const raw = row.original.created_at ?? row.original.date;
+          const date = raw ? new Date(raw) : null;
+          if (!date || Number.isNaN(date.getTime())) {
+            return <span className="text-xs text-slate-400">Sin fecha</span>;
+          }
+          return (
+            <span className="text-sm text-slate-500 dark:text-slate-400">
+              {new Intl.DateTimeFormat('es-ES', {
+                day: '2-digit',
+                month: 'short',
+                year: 'numeric'
+              })
+                .format(date)
+                .replace('.', '')}
+            </span>
+          );
+        }
+      },
+      {
+        id: 'actions',
+        header: () => <span className="sr-only">Acciones</span>,
+        enableSorting: false,
+        cell: ({ row }) => (
+          <div className="flex items-center justify-end gap-2">
+            <Button
+              type="button"
+              size="icon"
+              variant="ghost"
+              className="h-9 w-9"
+              onClick={() => handleView(row.original)}
+              aria-label={`Ver post ${row.original.title}`}
+            >
+              <Eye className="h-4 w-4" aria-hidden="true" />
+            </Button>
+            <Button
+              type="button"
+              size="icon"
+              variant="ghost"
+              className="h-9 w-9"
+              onClick={() => handleEdit(row.original)}
+              aria-label={`Editar post ${row.original.title}`}
+            >
+              <Pencil className="h-4 w-4" aria-hidden="true" />
+            </Button>
+            <Button
+              type="button"
+              size="icon"
+              variant="ghost"
+              className="h-9 w-9 text-red-500 hover:text-red-600 dark:text-red-400 dark:hover:text-red-300"
+              onClick={() => handleDelete(row.original)}
+              aria-label={`Eliminar post ${row.original.title}`}
+            >
+              <Trash2 className="h-4 w-4" aria-hidden="true" />
+            </Button>
+          </div>
+        )
+      }
+    ],
+    [handleDelete, handleEdit, handleView]
+  );
+
+  const toggleTagFilter = (tagValue) => {
+    if (postsState.tags.includes(tagValue)) {
+      setPostsTags(postsState.tags.filter((tag) => tag !== tagValue));
+    } else {
+      setPostsTags([...postsState.tags, tagValue]);
     }
-    return `Se eliminará "${confirmState.post.title}" del backoffice actual. Cuando el backend esté disponible se enviará la petición definitiva.`;
-  }, [confirmState.post]);
+  };
+
+  const tagOptionsUnion = useMemo(() => {
+    const map = new Map();
+    tags.forEach((option) => {
+      map.set(option.value.toLowerCase(), option);
+    });
+    (postsState.tags ?? []).forEach((value) => {
+      const key = value.toLowerCase();
+      if (!map.has(key)) {
+        map.set(key, { value, label: value });
+      }
+    });
+    return Array.from(map.values()).sort((a, b) => a.label.localeCompare(b.label, 'es'));
+  }, [postsState.tags, tags]);
+
+  const selectedTagOptions = useMemo(
+    () =>
+      tagOptionsUnion.filter((option) =>
+        postsState.tags.some((tagValue) => tagValue.toLowerCase() === option.value.toLowerCase())
+      ),
+    [postsState.tags, tagOptionsUnion]
+  );
+
+  const toolbar = (
+    <div className="flex w-full flex-col gap-4">
+      <div className="flex flex-wrap items-center gap-2">
+        {STATUS_OPTIONS.map((option) => (
+          <Button
+            key={option.value}
+            type="button"
+            size="sm"
+            variant={postsState.status === option.value ? 'secondary' : 'ghost'}
+            onClick={() => setPostsStatus(option.value)}
+          >
+            {option.label}
+          </Button>
+        ))}
+        <Button type="button" variant="ghost" size="sm" onClick={resetPosts}>
+          Limpiar filtros
+        </Button>
+      </div>
+      <div className="grid gap-3 lg:grid-cols-3">
+        <label className="flex flex-col gap-2 text-sm text-slate-500 dark:text-slate-400">
+          <span className="text-xs font-semibold uppercase tracking-wide text-slate-400">Ordenar por</span>
+          <select
+            value={postsState.ordering}
+            onChange={(event) => setPostsOrdering(event.target.value)}
+            className="w-full rounded-2xl border border-slate-200 bg-white px-4 py-2 text-sm text-slate-600 shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-200"
+          >
+            {ORDER_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex flex-col gap-2 text-sm text-slate-500 dark:text-slate-400">
+          <span className="text-xs font-semibold uppercase tracking-wide text-slate-400">Categoría</span>
+          <select
+            value={postsState.category}
+            onChange={(event) => setPostsCategory(event.target.value)}
+            className="w-full rounded-2xl border border-slate-200 bg-white px-4 py-2 text-sm text-slate-600 shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-200"
+          >
+            <option value="">Todas las categorías</option>
+            {categories.map((category) => (
+              <option key={category.value} value={category.value}>
+                {category.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <div className="flex flex-col gap-2 text-sm text-slate-500 dark:text-slate-400">
+          <span className="text-xs font-semibold uppercase tracking-wide text-slate-400">Filtrar por tags</span>
+          <Select
+            isMulti
+            value={selectedTagOptions}
+            options={tagOptionsUnion}
+            onChange={(selected) => {
+              const values = Array.isArray(selected) ? selected.map((option) => option.value) : [];
+              setPostsTags(values);
+            }}
+            placeholder="Selecciona uno o más tags"
+            styles={tagSelectStyles}
+            classNamePrefix="dashboard-tag-filter"
+            closeMenuOnSelect={false}
+            isClearable
+            noOptionsMessage={() => 'Sin coincidencias'}
+            aria-label="Filtrar posts por tags"
+          />
+        </div>
+      </div>
+      {tagOptionsUnion.length > 0 ? (
+        <div className="flex flex-wrap items-center gap-2 text-sm">
+          <span className="text-xs font-semibold uppercase tracking-wide text-slate-400">Etiquetas populares</span>
+          {tagOptionsUnion.slice(0, 12).map((tag) => {
+            const isActive = postsState.tags.some((value) => value.toLowerCase() === tag.value.toLowerCase());
+            return (
+              <Button
+                key={tag.value}
+                type="button"
+                size="sm"
+                variant={isActive ? 'secondary' : 'ghost'}
+                onClick={() => toggleTagFilter(tag.value)}
+              >
+                #{tag.label.replace(/ \(.*\)$/, '')}
+              </Button>
+            );
+          })}
+        </div>
+      ) : null}
+    </div>
+  );
 
   return (
     <div className="space-y-8">
-      <DataTable data={posts} isLoading={isLoading} onView={handleView} onEdit={handleEdit} onDelete={handleDelete} />
+      <DataTable
+        columns={columns}
+        data={posts}
+        isLoading={isLoading}
+        pageIndex={pageIndex}
+        pageSize={postsState.pageSize}
+        pageCount={pageCount}
+        onPageChange={(nextIndex) => setPostsPagination({ page: nextIndex + 1, pageSize: postsState.pageSize })}
+        renderToolbar={toolbar}
+        loadingMessage="Cargando posts..."
+        emptyState={{
+          title: 'Sin posts que mostrar',
+          description: 'Ajusta los filtros o crea una nueva publicación.',
+          action: (
+            <Button type="button" onClick={handleCreate}>
+              Crear post
+            </Button>
+          )
+        }}
+      />
       <ConfirmModal
         open={confirmState.open}
         title="¿Deseas eliminar este post?"
-        description={modalDescription}
-        confirmLabel="Eliminar post"
+        description={confirmState.title ? `Se eliminará "${confirmState.title}" del backoffice.` : null}
+        confirmLabel="Eliminar"
         cancelLabel="Cancelar"
-        onCancel={() => setConfirmState({ open: false, post: null, isDeleting: false })}
+        onCancel={() => setConfirmState({ open: false, slug: null, title: '', loading: false })}
         onConfirm={confirmDelete}
         tone="danger"
-        loading={confirmState.isDeleting}
+        loading={confirmState.loading}
       />
+      <div className="text-sm text-slate-500 dark:text-slate-400">
+        Mostrando {posts.length} de {totalCount} resultados
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/dashboard/DashboardTags.jsx
+++ b/frontend/src/pages/dashboard/DashboardTags.jsx
@@ -1,0 +1,305 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Modal } from 'flowbite-react';
+import slugify from 'slugify';
+import { toast } from 'sonner';
+import { Pencil, Plus, Trash2 } from 'lucide-react';
+import { useDashboardLayout } from '../../layouts/DashboardLayout.jsx';
+import {
+  useDashboardStore,
+  selectTagsState
+} from '../../store/dashboard.js';
+import { listTags, createTag, updateTag, deleteTag } from '../../services/api.js';
+import { Button } from '../../components/ui/button.jsx';
+import { Input } from '../../components/ui/input.jsx';
+import ConfirmModal from '../../components/backoffice/ConfirmModal.jsx';
+
+const normalizeName = (value) => value.trim();
+
+const dedupeTags = (tags) => {
+  const map = new Map();
+  tags.forEach((tag) => {
+    if (!tag) return;
+    const key = (tag.slug ?? tag.id ?? tag.name ?? '').toString().toLowerCase();
+    if (!key) return;
+    if (!map.has(key)) {
+      map.set(key, { ...tag });
+    } else {
+      const existing = map.get(key);
+      map.set(key, {
+        ...existing,
+        ...tag,
+        usage: Math.max(existing?.usage ?? 0, tag?.usage ?? 0)
+      });
+    }
+  });
+  return Array.from(map.values()).sort((a, b) => (a.name ?? '').localeCompare(b.name ?? '', 'es'));
+};
+
+function DashboardTags() {
+  const { setHeader } = useDashboardLayout();
+  const tagsState = useDashboardStore(selectTagsState);
+  const setTagSearch = useDashboardStore((state) => state.setTagSearch);
+  const resetTags = useDashboardStore((state) => state.resetTags);
+
+  const [tags, setTags] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [modalState, setModalState] = useState({ open: false, mode: 'create', id: null, value: '' });
+  const [deleteState, setDeleteState] = useState({ open: false, id: null, name: '', loading: false });
+  const inputRef = useRef(null);
+
+  useEffect(() => {
+    setHeader({
+      title: 'Etiquetas',
+      description: 'Gestiona las etiquetas disponibles para tus publicaciones.',
+      showSearch: false,
+      actions: (
+        <Button type="button" size="sm" onClick={() => setModalState({ open: true, mode: 'create', id: null, value: '' })}>
+          <Plus className="mr-2 h-4 w-4" aria-hidden="true" />
+          Nueva etiqueta
+        </Button>
+      )
+    });
+  }, [setHeader]);
+
+  useEffect(() => {
+    const fetchTags = async () => {
+      setIsLoading(true);
+      try {
+        const response = await listTags();
+        const normalized = Array.isArray(response)
+          ? response
+          : [];
+        setTags(dedupeTags(normalized));
+      } catch (error) {
+        toast.error('No pudimos cargar las etiquetas, intenta de nuevo.');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchTags();
+  }, []);
+
+  const filteredTags = useMemo(() => {
+    const searchTerm = tagsState.search.trim().toLowerCase();
+    if (!searchTerm) {
+      return tags;
+    }
+    return tags.filter((tag) => tag.name?.toLowerCase().includes(searchTerm));
+  }, [tags, tagsState.search]);
+
+  const openEditModal = (tag) => {
+    setModalState({ open: true, mode: 'edit', id: tag.id ?? tag.slug ?? tag.name, value: tag.name ?? '' });
+  };
+
+  const closeModal = () => {
+    setModalState({ open: false, mode: 'create', id: null, value: '' });
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    const name = normalizeName(modalState.value);
+    if (!name) {
+      toast.error('El nombre de la etiqueta es obligatorio.');
+      return;
+    }
+
+    const duplicate = tags.some((tag) => {
+      if (!tag?.name) return false;
+      const sameName = tag.name.toLowerCase() === name.toLowerCase();
+      if (!sameName) return false;
+      if (modalState.mode === 'edit') {
+        const identifier = modalState.id;
+        return tag.id !== identifier && tag.slug !== identifier && tag.name !== identifier;
+      }
+      return true;
+    });
+
+    if (duplicate) {
+      toast.error('Ya existe una etiqueta con ese nombre.');
+      return;
+    }
+
+    try {
+      if (modalState.mode === 'edit' && modalState.id) {
+        const updated = await updateTag(modalState.id, { name });
+        setTags((prev) =>
+          dedupeTags(
+            prev.map((tag) =>
+              tag.id === modalState.id || tag.slug === modalState.id
+                ? { ...tag, ...updated, name: updated?.name ?? name }
+                : tag
+            )
+          )
+        );
+        toast.success('Etiqueta actualizada.');
+      } else {
+        const created = await createTag({ name });
+        setTags((prev) => dedupeTags([{ ...created, name: created?.name ?? name }, ...prev]));
+        toast.success('Etiqueta creada.');
+      }
+      closeModal();
+    } catch (error) {
+      toast.error(error?.message ?? 'No se pudo guardar la etiqueta.');
+    }
+  };
+
+  const confirmDelete = async () => {
+    if (!deleteState.id) {
+      return;
+    }
+    setDeleteState((prev) => ({ ...prev, loading: true }));
+    try {
+      await deleteTag(deleteState.id);
+      setTags((prev) => dedupeTags(prev.filter((tag) => tag.id !== deleteState.id && tag.slug !== deleteState.id)));
+      toast.success('Etiqueta eliminada.');
+    } catch (error) {
+      toast.error(error?.message ?? 'No se pudo eliminar la etiqueta.');
+    } finally {
+      setDeleteState({ open: false, id: null, name: '', loading: false });
+    }
+  };
+
+  const computedSlug = useMemo(
+    () => slugify(modalState.value || '', { lower: true, strict: true }),
+    [modalState.value]
+  );
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-3 rounded-3xl border border-slate-200/70 bg-white/80 p-6 shadow-sm backdrop-blur dark:border-slate-800/70 dark:bg-slate-900/70">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <label className="flex flex-col gap-1 text-sm text-slate-500 dark:text-slate-400">
+            <span className="text-xs font-semibold uppercase tracking-wide text-slate-400">Buscar etiqueta</span>
+            <Input
+              type="search"
+              value={tagsState.search}
+              onChange={(event) => setTagSearch(event.target.value)}
+              placeholder="Filtra por nombre"
+              aria-label="Buscar etiqueta"
+            />
+          </label>
+          <Button type="button" variant="ghost" size="sm" onClick={resetTags}>
+            Restablecer filtros
+          </Button>
+        </div>
+        <div className="overflow-hidden rounded-3xl border border-slate-200/70 dark:border-slate-800/70">
+          <table className="min-w-full divide-y divide-slate-200 dark:divide-slate-800">
+            <thead className="bg-slate-50/80 dark:bg-slate-900/70">
+              <tr>
+                <th scope="col" className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-400">
+                  Nombre
+                </th>
+                <th scope="col" className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-400">
+                  Slug
+                </th>
+                <th scope="col" className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-400">
+                  Uso
+                </th>
+                <th scope="col" className="px-6 py-3 text-right text-xs font-semibold uppercase tracking-wide text-slate-400">
+                  Acciones
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-200 bg-white dark:divide-slate-800 dark:bg-slate-950/30">
+              {isLoading ? (
+                <tr>
+                  <td colSpan={4} className="px-6 py-16 text-center text-sm text-slate-500 dark:text-slate-400">
+                    Cargando etiquetas...
+                  </td>
+                </tr>
+              ) : filteredTags.length === 0 ? (
+                <tr>
+                  <td colSpan={4} className="px-6 py-16 text-center text-sm text-slate-500 dark:text-slate-400">
+                    No se encontraron etiquetas con los criterios indicados.
+                  </td>
+                </tr>
+              ) : (
+                filteredTags.map((tag) => (
+                  <tr key={tag.id ?? tag.slug ?? tag.name}>
+                    <td className="px-6 py-3 text-sm font-semibold text-slate-700 dark:text-slate-100">{tag.name}</td>
+                    <td className="px-6 py-3 text-sm text-slate-500 dark:text-slate-400">{tag.slug ?? '—'}</td>
+                    <td className="px-6 py-3 text-sm text-slate-500 dark:text-slate-400">{tag.usage ?? 0}</td>
+                    <td className="px-6 py-3 text-right">
+                      <div className="flex items-center justify-end gap-2">
+                        <Button type="button" size="icon" variant="ghost" onClick={() => openEditModal(tag)} aria-label={`Editar ${tag.name}`}>
+                          <Pencil className="h-4 w-4" aria-hidden="true" />
+                        </Button>
+                        <Button
+                          type="button"
+                          size="icon"
+                          variant="ghost"
+                          className="text-red-500 hover:text-red-600 dark:text-red-400 dark:hover:text-red-300"
+                          onClick={() => setDeleteState({ open: true, id: tag.id ?? tag.slug ?? tag.name, name: tag.name ?? '', loading: false })}
+                          aria-label={`Eliminar ${tag.name}`}
+                        >
+                          <Trash2 className="h-4 w-4" aria-hidden="true" />
+                        </Button>
+                      </div>
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+        <p className="text-xs text-slate-500 dark:text-slate-400">
+          {filteredTags.length} etiqueta(s) de {tags.length} disponibles.
+        </p>
+      </div>
+
+      <Modal
+        show={modalState.open}
+        size="md"
+        onClose={closeModal}
+        initialFocus={inputRef.current ?? undefined}
+        aria-labelledby="tag-modal-title"
+      >
+        <Modal.Header>
+          <h2 id="tag-modal-title" className="text-lg font-semibold text-slate-900 dark:text-white">
+            {modalState.mode === 'edit' ? 'Editar etiqueta' : 'Nueva etiqueta'}
+          </h2>
+        </Modal.Header>
+        <form onSubmit={handleSubmit}>
+          <Modal.Body className="space-y-3">
+            <label className="flex flex-col gap-1 text-sm text-slate-600 dark:text-slate-300" htmlFor="tag-name">
+              Nombre de la etiqueta
+              <Input
+                id="tag-name"
+                ref={inputRef}
+                value={modalState.value}
+                onChange={(event) => setModalState((prev) => ({ ...prev, value: event.target.value }))}
+                placeholder="Ej. rendimiento"
+                autoFocus
+                aria-describedby="tag-slug-preview"
+              />
+            </label>
+            <p id="tag-slug-preview" className="text-xs text-slate-500 dark:text-slate-400">
+              Slug previsto: {computedSlug || '—'}
+            </p>
+          </Modal.Body>
+          <Modal.Footer className="flex items-center justify-end gap-2">
+            <Button type="button" variant="ghost" onClick={closeModal}>
+              Cancelar
+            </Button>
+            <Button type="submit">
+              {modalState.mode === 'edit' ? 'Guardar cambios' : 'Crear etiqueta'}
+            </Button>
+          </Modal.Footer>
+        </form>
+      </Modal>
+
+      <ConfirmModal
+        open={deleteState.open}
+        title="¿Eliminar etiqueta?"
+        description={deleteState.name ? `Se eliminará "${deleteState.name}" de la lista.` : null}
+        onCancel={() => setDeleteState({ open: false, id: null, name: '', loading: false })}
+        onConfirm={confirmDelete}
+        tone="danger"
+        loading={deleteState.loading}
+      />
+    </div>
+  );
+}
+
+export default DashboardTags;

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,19 +1,19 @@
 import axios from 'axios';
+import slugify from 'slugify';
 import postsMock from '../data/posts.json';
 import commentsMock from '../data/comments.json';
-import { API_BASE_URL } from '../utils/apiBase.js';
 
 export const ACCESS_TOKEN_KEY = 'codextest.accessToken';
 export const REFRESH_TOKEN_KEY = 'codextest.refreshToken';
 
 const api = axios.create({
-  baseURL: API_BASE_URL,
-  withCredentials: false
+  baseURL: '/api/',
+  withCredentials: true
 });
 
 const refreshClient = axios.create({
-  baseURL: API_BASE_URL,
-  withCredentials: false
+  baseURL: '/api/',
+  withCredentials: true
 });
 
 let refreshPromise = null;
@@ -41,11 +41,13 @@ export const storeTokens = ({ access, refresh }) => {
   } else {
     window.localStorage.removeItem(ACCESS_TOKEN_KEY);
   }
+
   if (refresh) {
     window.localStorage.setItem(REFRESH_TOKEN_KEY, refresh);
   } else {
     window.localStorage.removeItem(REFRESH_TOKEN_KEY);
   }
+
   emitEvent('auth:tokens', { access, refresh });
 };
 
@@ -130,7 +132,713 @@ api.interceptors.response.use(
   }
 );
 
-export default api;
+const toApiError = (error) => {
+  if (axios.isAxiosError(error)) {
+    const status = error.response?.status ?? null;
+    const data = error.response?.data ?? null;
+    const detail =
+      (data && typeof data === 'object' && data.detail && typeof data.detail === 'string'
+        ? data.detail
+        : null) ?? error.message ?? 'Se produjo un error inesperado.';
+    const normalizedError = new Error(detail);
+    normalizedError.status = status;
+    normalizedError.data = data;
+    normalizedError.original = error;
+    return normalizedError;
+  }
+
+  const normalizedError = new Error(error?.message ?? 'Se produjo un error inesperado.');
+  normalizedError.status = null;
+  normalizedError.data = null;
+  normalizedError.original = error;
+  return normalizedError;
+};
+
+const paramsSerializer = (params = {}) => {
+  const searchParams = new URLSearchParams();
+
+  Object.entries(params).forEach(([key, value]) => {
+    if (value === undefined || value === null) {
+      return;
+    }
+
+    if (Array.isArray(value)) {
+      value
+        .map((item) => (typeof item === 'string' ? item.trim() : item))
+        .filter((item) => item !== undefined && item !== null && item !== '')
+        .forEach((item) => searchParams.append(key, item));
+      return;
+    }
+
+    if (typeof value === 'string') {
+      const trimmed = value.trim();
+      if (trimmed) {
+        searchParams.append(key, trimmed);
+      }
+      return;
+    }
+
+    searchParams.append(key, value);
+  });
+
+  return searchParams.toString();
+};
+
+const sanitizeSearch = (value) => (value || '').toString().trim();
+
+const sanitizeTags = (tags) => {
+  if (!Array.isArray(tags)) {
+    return [];
+  }
+  const unique = new Set();
+  tags.forEach((tag) => {
+    if (typeof tag !== 'string') return;
+    const normalized = tag.trim();
+    if (normalized) {
+      unique.add(normalized);
+    }
+  });
+  return Array.from(unique);
+};
+
+const computeStatusFromDate = (dateValue) => {
+  if (!dateValue) {
+    return 'published';
+  }
+  const parsed = new Date(dateValue);
+  if (Number.isNaN(parsed.getTime())) {
+    return 'published';
+  }
+  const today = new Date();
+  if (parsed.getTime() > today.getTime()) {
+    return 'scheduled';
+  }
+  return 'published';
+};
+
+const normalizePostResult = (post) => {
+  if (!post) {
+    return null;
+  }
+
+  const categories = Array.isArray(post.categories) ? post.categories : [];
+  const categoriesDetail = Array.isArray(post.categories_detail) ? post.categories_detail : [];
+  const tags = Array.isArray(post.tags) ? post.tags : [];
+  const createdAt = post.created_at ?? post.date ?? null;
+  const status = computeStatusFromDate(createdAt);
+
+  return {
+    ...post,
+    categories,
+    categories_detail: categoriesDetail,
+    tags,
+    created_at: createdAt,
+    status,
+    publishedAt: createdAt
+  };
+};
+
+const filterPostsByStatus = (posts, status) => {
+  if (status === 'all') {
+    return posts;
+  }
+  return posts.filter((item) => item.status === status);
+};
+
+const paginateResults = (items, page, pageSize) => {
+  const start = (page - 1) * pageSize;
+  return items.slice(start, start + pageSize);
+};
+
+const buildMockPostsResponse = ({
+  page,
+  pageSize,
+  search,
+  ordering,
+  category,
+  tags,
+  status
+}) => {
+  const normalizedSearch = sanitizeSearch(search).toLowerCase();
+  const normalizedTags = sanitizeTags(tags).map((tag) => tag.toLowerCase());
+  const categoryFilter = typeof category === 'string' ? category.trim().toLowerCase() : '';
+
+  let results = postsMock.map((post) => normalizePostResult({
+    id: post.id,
+    slug: post.slug,
+    title: post.title,
+    excerpt: post.excerpt,
+    content: post.content,
+    tags: post.tags ?? [],
+    categories: post.categories ?? [],
+    categories_detail: post.categories_detail ?? [],
+    created_at: post.date,
+    image: post.image,
+    thumb: post.thumb,
+    imageAlt: post.imageAlt,
+    author: post.author
+  }));
+
+  if (normalizedSearch) {
+    results = results.filter((item) => {
+      const haystack = `${item.title} ${item.excerpt}`.toLowerCase();
+      const tagMatch = (item.tags ?? []).some((tag) => tag.toLowerCase().includes(normalizedSearch));
+      const categoryMatch = (item.categories ?? []).some((cat) => cat.toLowerCase().includes(normalizedSearch));
+      return haystack.includes(normalizedSearch) || tagMatch || categoryMatch;
+    });
+  }
+
+  if (categoryFilter) {
+    results = results.filter((item) =>
+      (item.categories ?? []).some((cat) => cat.toLowerCase() === categoryFilter)
+    );
+  }
+
+  if (normalizedTags.length > 0) {
+    results = results.filter((item) => {
+      const itemTags = (item.tags ?? []).map((tag) => tag.toLowerCase());
+      return normalizedTags.every((tag) => itemTags.includes(tag));
+    });
+  }
+
+  if (ordering === 'title') {
+    results.sort((a, b) => a.title.localeCompare(b.title, 'es'));
+  } else if (ordering === '-title') {
+    results.sort((a, b) => b.title.localeCompare(a.title, 'es'));
+  } else if (ordering === 'date' || ordering === 'created_at') {
+    results.sort((a, b) => new Date(a.created_at) - new Date(b.created_at));
+  } else {
+    results.sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+  }
+
+  results = filterPostsByStatus(results, status);
+
+  const total = results.length;
+  const paginated = paginateResults(results, page, pageSize);
+
+  return {
+    count: total,
+    results: paginated,
+    next: null,
+    previous: null
+  };
+};
+
+const buildMockCommentsResponse = (slug, { page, pageSize, ordering }) => {
+  const normalizedSlug = (slug || '').toString().trim();
+  let results = commentsMock
+    .filter((comment) => comment.post === normalizedSlug)
+    .map((comment) => ({
+      ...comment,
+      created_at: comment.created_at ?? comment.date ?? new Date().toISOString()
+    }));
+
+  if (ordering === 'created_at') {
+    results.sort((a, b) => new Date(a.created_at) - new Date(b.created_at));
+  } else {
+    results.sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+  }
+
+  const total = results.length;
+  const paginated = paginateResults(results, page, pageSize);
+
+  return {
+    count: total,
+    results: paginated,
+    next: null,
+    previous: null
+  };
+};
+
+const TAG_STORAGE_KEY = 'dashboard:tags';
+const memoryTagStore = { value: [] };
+
+const readStoredTags = () => {
+  try {
+    if (isBrowser) {
+      const raw = window.localStorage.getItem(TAG_STORAGE_KEY);
+      if (!raw) {
+        return [];
+      }
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) {
+        return parsed;
+      }
+    }
+  } catch (error) {
+    console.warn('No fue posible leer las etiquetas almacenadas.', error);
+  }
+  return memoryTagStore.value ?? [];
+};
+
+const persistStoredTags = (tags) => {
+  const payload = Array.isArray(tags) ? tags : [];
+  memoryTagStore.value = payload;
+  if (!isBrowser) {
+    return;
+  }
+  try {
+    window.localStorage.setItem(TAG_STORAGE_KEY, JSON.stringify(payload));
+  } catch (error) {
+    console.warn('No fue posible persistir las etiquetas en localStorage.', error);
+  }
+};
+
+const slugifyTag = (value) =>
+  String(value ?? '')
+    .trim()
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '');
+
+const mergeTags = (base, extra) => {
+  const map = new Map();
+  base.forEach((tag) => {
+    if (!tag || !tag.name) return;
+    const key = tag.name.toLowerCase();
+    map.set(key, { ...tag });
+  });
+  extra.forEach((tag) => {
+    if (!tag || !tag.name) return;
+    const key = tag.name.toLowerCase();
+    if (!map.has(key)) {
+      map.set(key, { ...tag });
+    }
+  });
+  return Array.from(map.values()).sort((a, b) => a.name.localeCompare(b.name, 'es'));
+};
+
+const buildTagCollectionFromPosts = (posts) => {
+  const lookup = new Map();
+  posts.forEach((post) => {
+    const tags = Array.isArray(post.tags) ? post.tags : [];
+    tags.forEach((tag) => {
+      const name = typeof tag === 'string' ? tag : tag?.name;
+      if (!name) {
+        return;
+      }
+      const key = name.toLowerCase();
+      if (!lookup.has(key)) {
+        lookup.set(key, {
+          id: key,
+          name,
+          slug: slugifyTag(name),
+          usage: 1
+        });
+      } else {
+        const item = lookup.get(key);
+        item.usage = (item.usage ?? 0) + 1;
+      }
+    });
+  });
+  return Array.from(lookup.values());
+};
+
+const extractCategoriesFromMocks = () => {
+  const categories = new Map();
+  postsMock.forEach((post) => {
+    const details = Array.isArray(post.categories_detail) ? post.categories_detail : [];
+    details.forEach((category) => {
+      if (!category?.slug) return;
+      if (!categories.has(category.slug)) {
+        categories.set(category.slug, {
+          name: category.name ?? category.slug,
+          slug: category.slug,
+          description: category.description ?? '',
+          is_active: category.is_active ?? true,
+          post_count: 1
+        });
+      } else {
+        const stored = categories.get(category.slug);
+        stored.post_count = (stored.post_count ?? 0) + 1;
+      }
+    });
+  });
+  return Array.from(categories.values()).sort((a, b) => a.name.localeCompare(b.name, 'es'));
+};
+
+export async function listPosts(params = {}) {
+  const {
+    page = 1,
+    pageSize = 10,
+    search = '',
+    ordering = '-date',
+    category,
+    tags = [],
+    status = 'all'
+  } = params;
+
+  const requestParams = {
+    page,
+    page_size: pageSize,
+    search: sanitizeSearch(search) || undefined,
+    ordering: ordering || undefined,
+    category: category || undefined
+  };
+
+  const normalizedTags = sanitizeTags(tags);
+  if (normalizedTags.length > 0) {
+    requestParams['tags__name'] = normalizedTags;
+  }
+
+  try {
+    const response = await api.get('posts/', {
+      params: requestParams,
+      paramsSerializer
+    });
+    const payload = response.data ?? {};
+    const results = Array.isArray(payload.results) ? payload.results.map(normalizePostResult) : [];
+    const filteredResults = filterPostsByStatus(results, status);
+    if (status !== 'all') {
+      const adjusted = {
+        count: filteredResults.length,
+        results: paginateResults(filteredResults, page, pageSize),
+        next: null,
+        previous: null
+      };
+      return adjusted;
+    }
+    return {
+      ...payload,
+      results
+    };
+  } catch (error) {
+    if (import.meta.env?.DEV) {
+      console.info('Fallo al listar posts desde la API, usando datos mock.', error);
+    }
+    return buildMockPostsResponse({
+      page,
+      pageSize,
+      search,
+      ordering,
+      category,
+      tags,
+      status
+    });
+  }
+}
+
+export async function getPost(slug) {
+  if (!slug) {
+    throw new Error('Debes indicar el slug del post.');
+  }
+  try {
+    const response = await api.get(`posts/${slug}/`);
+    return normalizePostResult(response.data);
+  } catch (error) {
+    if (import.meta.env?.DEV) {
+      console.info(`Fallo al obtener el post ${slug}, buscando en datos mock.`, error);
+    }
+    const fallback = postsMock.find((post) => post.slug === slug);
+    if (!fallback) {
+      throw toApiError(error);
+    }
+    return normalizePostResult({
+      id: fallback.id,
+      slug: fallback.slug,
+      title: fallback.title,
+      excerpt: fallback.excerpt,
+      content: fallback.content,
+      tags: fallback.tags ?? [],
+      categories: fallback.categories ?? [],
+      categories_detail: fallback.categories_detail ?? [],
+      created_at: fallback.date,
+      image: fallback.image,
+      thumb: fallback.thumb,
+      imageAlt: fallback.imageAlt,
+      author: fallback.author
+    });
+  }
+}
+
+export async function createPost(data) {
+  try {
+    const response = await api.post('posts/', data);
+    return normalizePostResult(response.data);
+  } catch (error) {
+    const normalized = toApiError(error);
+    if (normalized.status === 405) {
+      normalized.message =
+        normalized.message ?? 'La API no permite eliminar comentarios por ahora.';
+    }
+    throw normalized;
+  }
+}
+
+export async function updatePost(slug, data) {
+  if (!slug) {
+    throw new Error('Debes indicar el slug del post a editar.');
+  }
+  try {
+    const response = await api.put(`posts/${slug}/`, data);
+    return normalizePostResult(response.data);
+  } catch (error) {
+    throw toApiError(error);
+  }
+}
+
+export async function deletePost(slug) {
+  if (!slug) {
+    throw new Error('Debes indicar el slug del post a eliminar.');
+  }
+  try {
+    await api.delete(`posts/${slug}/`);
+    return { success: true };
+  } catch (error) {
+    throw toApiError(error);
+  }
+}
+
+export async function listCategories(params = {}) {
+  const searchParams = {
+    q: sanitizeSearch(params.search),
+    is_active:
+      typeof params.isActive === 'boolean'
+        ? params.isActive
+          ? 'true'
+          : 'false'
+        : undefined,
+    with_counts: params.withCounts ? 'true' : undefined
+  };
+
+  try {
+    const response = await api.get('categories/', {
+      params: searchParams,
+      paramsSerializer
+    });
+    const payload = response.data ?? {};
+    if (Array.isArray(payload.results)) {
+      return payload;
+    }
+    if (Array.isArray(payload)) {
+      return payload;
+    }
+    return [];
+  } catch (error) {
+    if (import.meta.env?.DEV) {
+      console.info('Fallo al listar categorías desde la API, usando datos mock.', error);
+    }
+    return extractCategoriesFromMocks();
+  }
+}
+
+export async function createCategory(data) {
+  try {
+    const response = await api.post('categories/', data);
+    return response.data;
+  } catch (error) {
+    throw toApiError(error);
+  }
+}
+
+export async function updateCategory(slug, data) {
+  if (!slug) {
+    throw new Error('Debes indicar el slug de la categoría a actualizar.');
+  }
+  try {
+    const response = await api.put(`categories/${slug}/`, data);
+    return response.data;
+  } catch (error) {
+    throw toApiError(error);
+  }
+}
+
+export async function deleteCategory(slug) {
+  if (!slug) {
+    throw new Error('Debes indicar el slug de la categoría a eliminar.');
+  }
+  try {
+    await api.delete(`categories/${slug}/`);
+    return { success: true };
+  } catch (error) {
+    throw toApiError(error);
+  }
+}
+
+const ensureTagId = (tag) => {
+  if (tag.id) {
+    return tag.id;
+  }
+  return `tag-${slugifyTag(tag.name)}-${Date.now()}`;
+};
+
+export async function listTags() {
+  const stored = readStoredTags();
+
+  try {
+    const response = await api.get('tags/');
+    const data = response.data;
+    if (Array.isArray(data?.results)) {
+      return mergeTags(data.results, stored);
+    }
+    if (Array.isArray(data)) {
+      return mergeTags(data, stored);
+    }
+  } catch (error) {
+    if (import.meta.env?.DEV) {
+      console.info('Fallo al listar etiquetas desde la API, usando datos mock.', error);
+    }
+  }
+
+  const posts = postsMock.map((post) => normalizePostResult(post));
+  const fromPosts = buildTagCollectionFromPosts(posts);
+  return mergeTags(fromPosts, stored);
+}
+
+export async function createTag(payload) {
+  const normalizedName = sanitizeSearch(payload?.name);
+  if (!normalizedName) {
+    throw new Error('Debes indicar un nombre para la etiqueta.');
+  }
+
+  try {
+    const response = await api.post('tags/', { name: normalizedName });
+    return response.data;
+  } catch (error) {
+    if (error?.response?.status && error.response.status !== 404) {
+      throw toApiError(error);
+    }
+    if (import.meta.env?.DEV) {
+      console.info('Creando etiqueta en modo local al no existir endpoint dedicado.', error);
+    }
+    const stored = readStoredTags();
+    const slug = slugifyTag(normalizedName);
+    const newTag = {
+      id: ensureTagId({ name: normalizedName }),
+      name: normalizedName,
+      slug,
+      usage: 0
+    };
+    persistStoredTags([...stored, newTag]);
+    return newTag;
+  }
+}
+
+export async function updateTag(tagId, payload) {
+  const normalizedName = sanitizeSearch(payload?.name);
+  if (!normalizedName) {
+    throw new Error('Debes indicar un nombre para la etiqueta.');
+  }
+
+  try {
+    const response = await api.put(`tags/${tagId}/`, { name: normalizedName });
+    return response.data;
+  } catch (error) {
+    if (error?.response?.status && ![404, 405].includes(error.response.status)) {
+      throw toApiError(error);
+    }
+    if (import.meta.env?.DEV) {
+      console.info('Actualizando etiqueta de manera local al no existir endpoint dedicado.', error);
+    }
+    const stored = readStoredTags();
+    const slug = slugifyTag(normalizedName);
+    const next = stored.map((tag) =>
+      tag.id === tagId
+        ? {
+            ...tag,
+            name: normalizedName,
+            slug
+          }
+        : tag
+    );
+    persistStoredTags(next);
+    return next.find((tag) => tag.id === tagId);
+  }
+}
+
+export async function deleteTag(tagId) {
+  if (!tagId) {
+    throw new Error('Debes indicar la etiqueta a eliminar.');
+  }
+
+  try {
+    await api.delete(`tags/${tagId}/`);
+    return { success: true };
+  } catch (error) {
+    if (error?.response?.status && ![404, 405].includes(error.response.status)) {
+      throw toApiError(error);
+    }
+    if (import.meta.env?.DEV) {
+      console.info('Eliminando etiqueta localmente al no existir endpoint dedicado.', error);
+    }
+    const stored = readStoredTags();
+    persistStoredTags(stored.filter((tag) => tag.id !== tagId));
+    return { success: true, simulated: true };
+  }
+}
+
+export async function listComments(slug, params = {}) {
+  if (!slug) {
+    throw new Error('Debes indicar el slug del post para listar comentarios.');
+  }
+  const {
+    page = 1,
+    pageSize = 10,
+    ordering = '-created_at'
+  } = params;
+
+  const requestParams = {
+    page,
+    page_size: pageSize,
+    ordering
+  };
+
+  try {
+    const response = await api.get(`posts/${slug}/comments/`, {
+      params: requestParams,
+      paramsSerializer
+    });
+    return response.data;
+  } catch (error) {
+    if (import.meta.env?.DEV) {
+      console.info('Fallo al listar comentarios desde la API, usando datos mock.', error);
+    }
+    return buildMockCommentsResponse(slug, { page, pageSize, ordering });
+  }
+}
+
+export async function createComment(slug, data) {
+  if (!slug) {
+    throw new Error('Debes indicar el slug del post.');
+  }
+  try {
+    const response = await api.post(`posts/${slug}/comments/`, data);
+    return response.data;
+  } catch (error) {
+    throw toApiError(error);
+  }
+}
+
+export async function updateComment(commentId, data) {
+  if (!commentId) {
+    throw new Error('Debes indicar el comentario a actualizar.');
+  }
+  try {
+    const response = await api.put(`comments/${commentId}/`, data);
+    return response.data;
+  } catch (error) {
+    throw toApiError(error);
+  }
+}
+
+export async function deleteComment(commentId) {
+  if (!commentId) {
+    throw new Error('Debes indicar el comentario a eliminar.');
+  }
+  try {
+    await api.delete(`comments/${commentId}/`);
+    return { success: true };
+  } catch (error) {
+    const normalized = toApiError(error);
+    if (normalized.status === 405) {
+      normalized.message =
+        normalized.message ?? 'La API no permite eliminar comentarios por ahora.';
+    }
+    throw normalized;
+  }
+}
 
 const MOCK_STATUS_SEQUENCE = ['published', 'published', 'draft', 'published', 'scheduled'];
 
@@ -249,31 +957,4 @@ export async function getDashboardStats() {
   }
 }
 
-export async function getPosts(params = {}) {
-  try {
-    const response = await api.get('dashboard/posts/', { params });
-    return response.data;
-  } catch (error) {
-    if (import.meta.env?.DEV) {
-      console.info('Usando posts mock para el dashboard hasta conectar con DRF.', error?.message);
-    }
-    const posts = getMockPosts();
-    return {
-      results: posts,
-      total: posts.length
-    };
-  }
-}
-
-export async function deletePost(postId) {
-  try {
-    await api.delete(`dashboard/posts/${postId}/`);
-    return { success: true };
-  } catch (error) {
-    if (import.meta.env?.DEV) {
-      console.info('Simulando eliminación de post hasta conectar con DRF.', error?.message);
-    }
-    await new Promise((resolve) => setTimeout(resolve, 650));
-    return { success: true, simulated: true };
-  }
-}
+export default api;

--- a/frontend/src/store/dashboard.js
+++ b/frontend/src/store/dashboard.js
@@ -1,7 +1,7 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 
-const sanitizeSearch = (value) => (value || '').toString().trim().toLowerCase();
+const sanitizeSearch = (value) => (value || '').toString().trim();
 
 const sanitizeTags = (tags) => {
   if (!Array.isArray(tags)) {
@@ -9,15 +9,79 @@ const sanitizeTags = (tags) => {
   }
   const unique = new Set();
   tags.forEach((tag) => {
-    if (typeof tag === 'string') {
-      const normalized = tag.trim().toLowerCase();
-      if (normalized) {
-        unique.add(normalized);
-      }
+    if (typeof tag !== 'string') return;
+    const normalized = tag.trim();
+    if (normalized) {
+      unique.add(normalized);
     }
   });
   return Array.from(unique);
 };
+
+const sanitizePostsStatus = (value) => {
+  if (['all', 'published', 'scheduled', 'draft'].includes(value)) {
+    return value;
+  }
+  return 'all';
+};
+
+const sanitizeOrdering = (value, fallback) => {
+  const allowed = ['-date', 'date', '-created_at', 'created_at', '-title', 'title'];
+  if (allowed.includes(value)) {
+    return value;
+  }
+  return fallback;
+};
+
+const sanitizePage = (value, fallback = 1) => {
+  const number = Number.parseInt(value, 10);
+  if (Number.isFinite(number) && number > 0) {
+    return number;
+  }
+  return fallback;
+};
+
+const sanitizePageSize = (value, fallback = 10) => {
+  const number = Number.parseInt(value, 10);
+  if (Number.isFinite(number) && number > 0 && number <= 100) {
+    return number;
+  }
+  return fallback;
+};
+
+const createDefaultSections = () => ({
+  posts: {
+    search: '',
+    status: 'all',
+    ordering: '-date',
+    page: 1,
+    pageSize: 10,
+    tags: [],
+    category: ''
+  },
+  tags: {
+    search: '',
+    ordering: 'name',
+    page: 1,
+    pageSize: 20
+  },
+  categories: {
+    search: '',
+    ordering: 'name',
+    page: 1,
+    pageSize: 20
+  },
+  comments: {
+    search: '',
+    ordering: '-created_at',
+    page: 1,
+    pageSize: 15,
+    status: 'all',
+    postSlug: ''
+  }
+});
+
+const SECTION_DEFAULTS = createDefaultSections();
 
 const storage = createJSONStorage(() => {
   if (typeof window === 'undefined') {
@@ -26,37 +90,237 @@ const storage = createJSONStorage(() => {
   return window.localStorage;
 });
 
+const cloneSection = (sectionKey) => ({ ...SECTION_DEFAULTS[sectionKey] });
+
 export const useDashboardStore = create(
   persist(
     (set, get) => ({
       sidebarCollapsed: false,
       mobileSidebarOpen: false,
       density: 'comfortable',
-      search: '',
-      statusFilter: 'all',
-      tagFilter: [],
-      pageIndex: 0,
-      pageSize: 8,
-      sortBy: 'publishedAt',
-      sortDirection: 'desc',
+      sections: createDefaultSections(),
       setSidebarCollapsed: (collapsed) => set({ sidebarCollapsed: Boolean(collapsed) }),
       toggleSidebarCollapsed: () => set((state) => ({ sidebarCollapsed: !state.sidebarCollapsed })),
       openMobileSidebar: () => set({ mobileSidebarOpen: true }),
       closeMobileSidebar: () => set({ mobileSidebarOpen: false }),
       setDensity: (density) => set({ density: density === 'compact' ? 'compact' : 'comfortable' }),
-      setSearch: (value) => set({ search: sanitizeSearch(value), pageIndex: 0 }),
-      setStatusFilter: (status) => set({ statusFilter: status || 'all', pageIndex: 0 }),
-      setTagFilter: (tags) => set({ tagFilter: sanitizeTags(tags), pageIndex: 0 }),
-      resetFilters: () => set({ search: '', statusFilter: 'all', tagFilter: [], pageIndex: 0 }),
-      setPagination: ({ pageIndex, pageSize }) => {
-        const nextPageIndex = Number.isFinite(pageIndex) && pageIndex >= 0 ? pageIndex : get().pageIndex;
-        const nextPageSize = Number.isFinite(pageSize) && pageSize > 0 ? pageSize : get().pageSize;
-        set({ pageIndex: nextPageIndex, pageSize: nextPageSize });
+      resetAllSections: () => set({ sections: createDefaultSections() }),
+      setSectionSearch: (sectionKey, value) => {
+        const currentSections = get().sections;
+        if (!currentSections?.[sectionKey]) {
+          return;
+        }
+        set({
+          sections: {
+            ...currentSections,
+            [sectionKey]: {
+              ...currentSections[sectionKey],
+              search: sanitizeSearch(value),
+              page: 1
+            }
+          }
+        });
       },
-      setSort: ({ sortBy, sortDirection }) => {
-        const nextSortBy = typeof sortBy === 'string' && sortBy ? sortBy : get().sortBy;
-        const nextDirection = sortDirection === 'asc' ? 'asc' : 'desc';
-        set({ sortBy: nextSortBy, sortDirection: nextDirection });
+      updateSection: (sectionKey, partialState) => {
+        const currentSections = get().sections;
+        if (!currentSections?.[sectionKey]) {
+          return;
+        }
+        set({
+          sections: {
+            ...currentSections,
+            [sectionKey]: {
+              ...currentSections[sectionKey],
+              ...partialState
+            }
+          }
+        });
+      },
+      resetSection: (sectionKey) => {
+        const currentSections = get().sections;
+        if (!currentSections?.[sectionKey]) {
+          return;
+        }
+        set({
+          sections: {
+            ...currentSections,
+            [sectionKey]: cloneSection(sectionKey)
+          }
+        });
+      },
+      setPostsFilters: (partial) => {
+        const currentSections = get().sections;
+        const current = currentSections.posts;
+        const next = {
+          ...current,
+          status: partial.status ? sanitizePostsStatus(partial.status) : current.status,
+          ordering: partial.ordering ? sanitizeOrdering(partial.ordering, current.ordering) : current.ordering,
+          category: typeof partial.category === 'string' ? partial.category : current.category,
+          tags: partial.tags ? sanitizeTags(partial.tags) : current.tags,
+          page: partial.page ? sanitizePage(partial.page, current.page) : current.page,
+          pageSize: partial.pageSize ? sanitizePageSize(partial.pageSize, current.pageSize) : current.pageSize
+        };
+        if (typeof partial.search === 'string') {
+          next.search = sanitizeSearch(partial.search);
+        }
+        set({
+          sections: {
+            ...currentSections,
+            posts: next
+          }
+        });
+      },
+      setPostsStatus: (status) => {
+        const currentSections = get().sections;
+        const current = currentSections.posts;
+        set({
+          sections: {
+            ...currentSections,
+            posts: {
+              ...current,
+              status: sanitizePostsStatus(status),
+              page: 1
+            }
+          }
+        });
+      },
+      setPostsOrdering: (ordering) => {
+        const currentSections = get().sections;
+        const current = currentSections.posts;
+        set({
+          sections: {
+            ...currentSections,
+            posts: {
+              ...current,
+              ordering: sanitizeOrdering(ordering, current.ordering)
+            }
+          }
+        });
+      },
+      setPostsPagination: ({ page, pageSize }) => {
+        const currentSections = get().sections;
+        const current = currentSections.posts;
+        set({
+          sections: {
+            ...currentSections,
+            posts: {
+              ...current,
+              page: sanitizePage(page, current.page),
+              pageSize: sanitizePageSize(pageSize, current.pageSize)
+            }
+          }
+        });
+      },
+      setPostsCategory: (category) => {
+        const currentSections = get().sections;
+        const current = currentSections.posts;
+        set({
+          sections: {
+            ...currentSections,
+            posts: {
+              ...current,
+              category: typeof category === 'string' ? category : '',
+              page: 1
+            }
+          }
+        });
+      },
+      setPostsTags: (tags) => {
+        const currentSections = get().sections;
+        const current = currentSections.posts;
+        set({
+          sections: {
+            ...currentSections,
+            posts: {
+              ...current,
+              tags: sanitizeTags(tags),
+              page: 1
+            }
+          }
+        });
+      },
+      resetPosts: () => {
+        const currentSections = get().sections;
+        set({
+          sections: {
+            ...currentSections,
+            posts: cloneSection('posts')
+          }
+        });
+      },
+      setCommentsFilters: (partial) => {
+        const currentSections = get().sections;
+        const current = currentSections.comments;
+        const next = {
+          ...current,
+          search: typeof partial.search === 'string' ? sanitizeSearch(partial.search) : current.search,
+          ordering: partial.ordering ?? current.ordering,
+          page: partial.page ? sanitizePage(partial.page, current.page) : current.page,
+          pageSize: partial.pageSize ? sanitizePageSize(partial.pageSize, current.pageSize) : current.pageSize,
+          status: partial.status ? sanitizePostsStatus(partial.status) : current.status,
+          postSlug: typeof partial.postSlug === 'string' ? partial.postSlug : current.postSlug
+        };
+        set({
+          sections: {
+            ...currentSections,
+            comments: next
+          }
+        });
+      },
+      resetComments: () => {
+        const currentSections = get().sections;
+        set({
+          sections: {
+            ...currentSections,
+            comments: cloneSection('comments')
+          }
+        });
+      },
+      setTagSearch: (value) => {
+        const currentSections = get().sections;
+        const current = currentSections.tags;
+        set({
+          sections: {
+            ...currentSections,
+            tags: {
+              ...current,
+              search: sanitizeSearch(value),
+              page: 1
+            }
+          }
+        });
+      },
+      resetTags: () => {
+        const currentSections = get().sections;
+        set({
+          sections: {
+            ...currentSections,
+            tags: cloneSection('tags')
+          }
+        });
+      },
+      setCategoriesSearch: (value) => {
+        const currentSections = get().sections;
+        const current = currentSections.categories;
+        set({
+          sections: {
+            ...currentSections,
+            categories: {
+              ...current,
+              search: sanitizeSearch(value),
+              page: 1
+            }
+          }
+        });
+      },
+      resetCategories: () => {
+        const currentSections = get().sections;
+        set({
+          sections: {
+            ...currentSections,
+            categories: cloneSection('categories')
+          }
+        });
       }
     }),
     {
@@ -65,28 +329,32 @@ export const useDashboardStore = create(
       partialize: (state) => ({
         sidebarCollapsed: state.sidebarCollapsed,
         density: state.density,
-        search: state.search,
-        statusFilter: state.statusFilter,
-        tagFilter: state.tagFilter,
-        pageSize: state.pageSize,
-        sortBy: state.sortBy,
-        sortDirection: state.sortDirection
+        sections: state.sections
       })
     }
   )
 );
 
-export const selectDashboardSearch = (state) => state.search;
-export const selectDashboardStatusFilter = (state) => state.statusFilter;
-export const selectDashboardTagFilter = (state) => state.tagFilter;
 export const selectDashboardDensity = (state) => state.density;
 export const selectDashboardSidebarCollapsed = (state) => state.sidebarCollapsed;
 export const selectDashboardMobileSidebarOpen = (state) => state.mobileSidebarOpen;
-export const selectDashboardPagination = (state) => ({
-  pageIndex: state.pageIndex,
-  pageSize: state.pageSize
+export const selectPostsState = (state) => state.sections.posts;
+export const selectTagsState = (state) => state.sections.tags;
+export const selectCategoriesState = (state) => state.sections.categories;
+export const selectCommentsState = (state) => state.sections.comments;
+
+export const selectPostsPagination = (state) => ({
+  page: state.sections.posts.page,
+  pageSize: state.sections.posts.pageSize
 });
-export const selectDashboardSorting = (state) => ({
-  sortBy: state.sortBy,
-  sortDirection: state.sortDirection
+
+export const selectPostsFilters = (state) => ({
+  status: state.sections.posts.status,
+  ordering: state.sections.posts.ordering,
+  category: state.sections.posts.category,
+  tags: state.sections.posts.tags,
+  search: state.sections.posts.search
 });
+
+export const selectPostsSearch = (state) => state.sections.posts.search;
+export const selectCommentsSearch = (state) => state.sections.comments.search;

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@tanstack/react-table": "^8.11.8",
         "axios": "^1.6.8",
         "class-variance-authority": "^0.7.0",
+        "dompurify": "^3.0.8",
         "flowbite": "^2.3.0",
         "flowbite-react": "^0.7.5",
         "framer-motion": "^11.0.0",
@@ -2263,6 +2264,13 @@
       "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
@@ -3025,6 +3033,15 @@
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.0.tgz",
+      "integrity": "sha512-r+f6MYR1gGN1eJv0TVQbhA7if/U7P87cdPl3HN5rikqaBSBxLiCb/b9O+2eG0cxz0ghyU+mU1QkbsOwERMYlWQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@tanstack/react-table": "^8.11.8",
     "axios": "^1.6.8",
     "class-variance-authority": "^0.7.0",
+    "dompurify": "^3.0.8",
     "flowbite": "^2.3.0",
     "flowbite-react": "^0.7.5",
     "framer-motion": "^11.0.0",


### PR DESCRIPTION
## Summary
- add nested dashboard routes for posts, tags, categories and comments plus adaptive layout search placeholders
- enhance the posts grid with reusable filters, tag multi-select, accessible modals and detailed previews
- complete tags, categories and comments management screens with validation, deduplication, reusable UI helpers and defensive API handling
- refresh navigation links and shared UI components to surface the new sections

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f56569d75883279a5e8170e341a2a8