### PR TITLE
Fix backoffice API base URL configuration

### DIFF
--- a/docs/frontend/README.md
+++ b/docs/frontend/README.md
@@ -89,6 +89,7 @@ Puedes añadir directorios específicos (`hooks`, `lib`, `layouts`, `assets`) si
 ### Gestión de estado y datos
 - Prefiere **estado local** con `useState` y **memoización** con `useMemo`/`useCallback`.
 - Usa **Context API** para cross-cutting concerns (tema, usuario, configuración).
+- La resolución de endpoints depende de `src/utils/apiBase.js`, que normaliza `import.meta.env.VITE_API_BASE_URL`. Está prohibido reemplazarlo por URLs hardcodeadas.
 - Si se requiere sincronizar datos remotos en el futuro, encapsula fetchers en `/frontend/src/lib/api.js` para facilitar pruebas.
 - Mantén los JSON de `data/` normalizados (IDs numéricos, slugs string, arrays de comentarios). Documenta el esquema en este archivo.
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -12,12 +12,14 @@ Este módulo vive dentro de `/frontend` del monorepo y contiene el cliente React
 
 ## Configuración de API
 
-La URL base se resuelve dinámicamente en `src/lib/apiClient.js` siguiendo esta prioridad:
+La URL base se resuelve dinámicamente en `src/utils/apiBase.js` siguiendo esta prioridad:
 
-1. `window.__ENV__?.API_BASE_URL` inyectado en tiempo de ejecución.
-2. `import.meta.env.VITE_API_BASE_URL` definido por Vite.
-3. `/api` durante el desarrollo local (usa el proxy configurado en `vite.config.js`).
-4. `https://backendblog.yampi.eu` como valor por defecto para builds de producción.
+1. `import.meta.env.VITE_API_BASE_URL` definido por Vite.
+2. `window.__ENV__?.API_BASE_URL` inyectado en tiempo de ejecución.
+3. `/api/` durante el desarrollo local (proxy configurado en `vite.config.js`).
+4. `https://backendblog.yampi.eu/api/` como valor por defecto para builds de producción.
+
+> **Importante:** ninguna parte del código puede hardcodear dominios del backend. Importa siempre `API_BASE_URL` o `resolveApiBaseUrl()` desde `src/utils/apiBase.js`.
 
 ### Endpoints consumidos
 

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import slugify from 'slugify';
+import { API_BASE_URL } from '../utils/apiBase.js';
 import postsMock from '../data/posts.json';
 import commentsMock from '../data/comments.json';
 
@@ -7,12 +8,12 @@ export const ACCESS_TOKEN_KEY = 'codextest.accessToken';
 export const REFRESH_TOKEN_KEY = 'codextest.refreshToken';
 
 const api = axios.create({
-  baseURL: '/api/',
+  baseURL: API_BASE_URL,
   withCredentials: true
 });
 
 const refreshClient = axios.create({
-  baseURL: '/api/',
+  baseURL: API_BASE_URL,
   withCredentials: true
 });
 

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,28 +1,58 @@
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 import { dirname, resolve } from 'path';
 import { fileURLToPath } from 'url';
 
 const repositoryBase = '/CodexTest/';
+const DEFAULT_PROXY_TARGET = 'https://backendblog.yampi.eu';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-export default defineConfig(({ command }) => ({
-  plugins: [react()],
-  base: command === 'build' ? repositoryBase : '/',
-  root: __dirname,
-  publicDir: resolve(__dirname, 'public'),
-  server: {
-    proxy: {
-      '/api': {
-        target: 'https://backendblog.yampi.eu',
-        changeOrigin: true,
-        secure: true
-      }
-    }
-  },
-  build: {
-    outDir: resolve(__dirname, '../dist'),
-    emptyOutDir: true
+const resolveProxyTarget = (rawValue) => {
+  if (typeof rawValue !== 'string') {
+    return DEFAULT_PROXY_TARGET;
   }
-}));
+
+  const trimmed = rawValue.trim();
+  if (!trimmed) {
+    return DEFAULT_PROXY_TARGET;
+  }
+
+  if (!/^https?:\/\//i.test(trimmed)) {
+    return DEFAULT_PROXY_TARGET;
+  }
+
+  try {
+    const url = new URL(trimmed);
+    return `${url.protocol}//${url.host}`;
+  } catch (error) {
+    console.warn('[vite] No fue posible resolver VITE_API_BASE_URL, usando proxy por defecto.', error);
+    return DEFAULT_PROXY_TARGET;
+  }
+};
+
+export default defineConfig(({ command, mode }) => {
+  const env = loadEnv(mode, process.cwd(), '');
+  const proxyTarget = resolveProxyTarget(env.VITE_API_BASE_URL);
+  const isSecureTarget = /^https:\/\//i.test(proxyTarget);
+
+  return {
+    plugins: [react()],
+    base: command === 'build' ? repositoryBase : '/',
+    root: __dirname,
+    publicDir: resolve(__dirname, 'public'),
+    server: {
+      proxy: {
+        '/api': {
+          target: proxyTarget,
+          changeOrigin: true,
+          secure: isSecureTarget
+        }
+      }
+    },
+    build: {
+      outDir: resolve(__dirname, '../dist'),
+      emptyOutDir: true
+    }
+  };
+});

--- a/instructions/agents_frontend.md
+++ b/instructions/agents_frontend.md
@@ -6,3 +6,4 @@ Resumen:
 - Ejecuta comandos con `npm` desde la raíz, ya que el pipeline existente depende de `npm ci` y `npm run build`.
 - Todos los archivos de código, assets y configuraciones específicas del cliente están bajo `/frontend`.
 - Mantén la compatibilidad con el despliegue en GitHub Pages definido en `.github/workflows/deploy.yml`.
+- **Respeta la resolución de API** en `src/utils/apiBase.js`: ninguna URL del backend puede hardcodearse; siempre usa `import.meta.env.VITE_API_BASE_URL`.

--- a/instructions/frontend/agents_frontend.md
+++ b/instructions/frontend/agents_frontend.md
@@ -13,6 +13,7 @@ Desarrolla el proyecto completo con todos sus archivos, carpetas y configuracion
 3. Instala y configura Flowbite y Flowbite React para los componentes UI.
 4. Usa npm como gestor de paquetes (los comandos se ejecutan desde la raíz del repositorio).
 5. Implementa React Router DOM versión 6 para la navegación.
+6. **Nunca hardcodees la URL del backend**: todas las llamadas deben apoyarse en `import.meta.env.VITE_API_BASE_URL` resuelta por `src/utils/apiBase.js`.
 
 ---
 
@@ -24,7 +25,7 @@ Desarrolla el proyecto completo con todos sus archivos, carpetas y configuracion
 - Los comentarios y posts deben estar en archivos JSON locales en la carpeta `/frontend/src/data`.
 - Implementa un componente Navbar con Flowbite React, responsivo y simple.
 - El diseño debe ser limpio, moderno y responsivo.
-- No hay backend ni base de datos, todo es estático.
+- El módulo consume la API REST mediante el helper `src/utils/apiBase.js`, que normaliza `VITE_API_BASE_URL` y define fallbacks controlados. Está prohibido reemplazarlo por strings directas.
 
 ---
 


### PR DESCRIPTION
## Summary
- ensure the backoffice axios clients reuse the normalized API_BASE_URL helper
- resolve the dev proxy target from VITE_API_BASE_URL instead of hardcoding the backend domain
- document the backend URL policy across the frontend agent guides and docs to avoid regressions

## Testing
- npm run build *(fails: missing dependency `sonner` in frontend/src/components/ui/sonner-provider.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68f57169c3fc8327b4ed5c0e4844ccb2