### PR TITLE
Ensure GitHub Pages build receives API base secret

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,8 @@ jobs:
 
       - name: Build
         run: npm run build
+        env:
+          VITE_API_BASE_URL: ${{ secrets.VITE_API_BASE_URL }}
 
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@v4


### PR DESCRIPTION
## Summary
- ensure the GitHub Actions build step exports the VITE_API_BASE_URL secret so Vite embeds the backend URL during compilation

## Testing
- npm run build *(fails: Rollup could not resolve "sonner" in frontend/src/components/ui/sonner-provider.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68f574e84e8483278f6e353342101459