### PR TITLE
Corrige carga del formulario en edición y añade acceso al inicio en el backoffice

### DIFF
--- a/frontend/src/components/backoffice/PostForm.jsx
+++ b/frontend/src/components/backoffice/PostForm.jsx
@@ -149,6 +149,11 @@ function PostForm({ mode, slug, onCancel, onSuccess }) {
   const contentValue = watch('content');
   const statusValue = watch('status');
   const autoSlugRef = useRef('');
+  const onCancelRef = useRef(onCancel);
+
+  useEffect(() => {
+    onCancelRef.current = onCancel;
+  }, [onCancel]);
 
   useEffect(() => {
     const newSlug = slugify(titleValue ?? '', { lower: true, strict: true });
@@ -230,12 +235,12 @@ function PostForm({ mode, slug, onCancel, onSuccess }) {
         });
       } catch (error) {
         toast.error('No se pudo cargar el post solicitado.');
-        if (onCancel) {
-          onCancel();
+        if (onCancelRef.current) {
+          onCancelRef.current();
         }
       }
     },
-    [mode, onCancel, reset]
+    [mode, reset]
   );
 
   useEffect(() => {

--- a/frontend/src/components/backoffice/Topbar.jsx
+++ b/frontend/src/components/backoffice/Topbar.jsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
-import { Menu, LogOut, Settings2, Search } from 'lucide-react';
+import { Home, Menu, LogOut, Settings2, Search } from 'lucide-react';
 import { useAuth } from '../../context/AuthContext.jsx';
 import ThemeToggle from '../ui/theme-toggle.jsx';
 import { Button } from '../ui/button.jsx';
@@ -108,6 +108,25 @@ function Topbar({
             </motion.div>
           </div>
           <div className="flex flex-wrap items-center gap-2 lg:justify-end">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="hidden sm:inline-flex"
+              onClick={() => navigate('/')}
+            >
+              Ir al inicio
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="inline-flex sm:hidden"
+              onClick={() => navigate('/')}
+              aria-label="Ir al inicio"
+            >
+              <Home className="h-4 w-4" aria-hidden="true" />
+            </Button>
             {actions}
             <ThemeToggle className="hidden lg:inline-flex" />
             {isAuthenticated ? (


### PR DESCRIPTION
## Summary
- evita reinicios innecesarios del formulario de posts manteniendo estable el manejador de cancelación
- agrega botones en la barra superior del backoffice para regresar al inicio tanto en escritorio como en móviles

## Testing
- npm run build *(falla: [vite]: Rollup failed to resolve import "sonner"...)*

------
https://chatgpt.com/codex/tasks/task_e_68f57e9ceab083278489fd8303ca8a64