### PR TITLE
Add skeleton loading components to landing page

### DIFF
--- a/frontend/src/components/landing/Hero.jsx
+++ b/frontend/src/components/landing/Hero.jsx
@@ -4,11 +4,21 @@ import Balancer from 'react-wrap-balancer';
 import { Link } from 'react-router-dom';
 import { Button } from '../ui/button.jsx';
 import { getHeroImage } from '../../lib/img.js';
+import HeroSkeleton from '../skeleton/HeroSkeleton.jsx';
 
 const MotionButton = motion(Button);
 
-function Hero() {
-  const heroImage = useMemo(() => getHeroImage('landing', 1280, 720), []);
+function Hero({ isLoading = false }) {
+  const heroImage = useMemo(() => {
+    if (isLoading) {
+      return null;
+    }
+    return getHeroImage('landing', 1280, 720);
+  }, [isLoading]);
+
+  if (isLoading) {
+    return <HeroSkeleton />;
+  }
 
   return (
     <section
@@ -32,8 +42,7 @@ function Hero() {
           </h1>
           <p className="mt-6 text-lg leading-relaxed text-slate-600 dark:text-slate-300">
             <Balancer>
-              Aprende a construir interfaces modernas, anima tus componentes con Framer Motion y aplica patrones productivos sin
-              perder la accesibilidad. Cada artículo llega con ejemplos listos para producción.
+              Aprende a construir interfaces modernas, anima tus componentes con Framer Motion y aplica patrones productivos sin perder la accesibilidad. Cada artículo llega con ejemplos listos para producción.
             </Balancer>
           </p>
           <div className="mt-10 flex flex-col items-center gap-4 sm:flex-row sm:justify-center lg:justify-start">

--- a/frontend/src/components/landing/LatestPosts.jsx
+++ b/frontend/src/components/landing/LatestPosts.jsx
@@ -1,11 +1,11 @@
-import { memo, useEffect, useMemo, useState } from 'react';
+import { memo, useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import Balancer from 'react-wrap-balancer';
-import { toast } from 'sonner';
-import { listLatestPosts } from '../../services/api.js';
 import { getPostImage } from '../../lib/img.js';
 import { createStagger, fadeInUp, hoverLift, inViewProps } from '../../lib/animation.js';
+import PostsGridSkeleton from '../skeleton/PostsGridSkeleton.jsx';
+import SectionHeadingSkeleton from '../skeleton/SectionHeadingSkeleton.jsx';
 
 const FALLBACK_LIMIT = 6;
 
@@ -24,51 +24,16 @@ const formatDate = (value) => {
   }
 };
 
-const SkeletonCard = ({ index }) => (
-  <div
-    className="relative flex flex-col overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-sm animate-in fade-in-50 zoom-in-95 dark:border-slate-800 dark:bg-slate-900"
-    style={{ animationDelay: `${index * 80}ms` }}
-  >
-    <div className="h-48 w-full bg-slate-200/70 dark:bg-slate-700/50 animate-pulse" />
-    <div className="space-y-3 p-6">
-      <div className="h-5 w-3/4 rounded-full bg-slate-200/80 dark:bg-slate-700/60 animate-pulse" />
-      <div className="h-4 w-2/3 rounded-full bg-slate-200/70 dark:bg-slate-700/50 animate-pulse" />
-      <div className="h-4 w-1/2 rounded-full bg-slate-200/60 dark:bg-slate-700/40 animate-pulse" />
-    </div>
-  </div>
-);
-
-function LatestPosts({ limit = FALLBACK_LIMIT }) {
-  const [state, setState] = useState({ posts: [], loading: true });
-
-  useEffect(() => {
-    let cancelled = false;
-
-    const fetchPosts = async () => {
-      setState((current) => ({ ...current, loading: true }));
-      try {
-        const results = await listLatestPosts({ limit });
-        if (cancelled) return;
-        setState({ posts: Array.isArray(results) ? results : [], loading: false });
-      } catch (error) {
-        if (cancelled) return;
-        setState({ posts: [], loading: false });
-        toast.error('No pudimos cargar las publicaciones recientes. Intenta de nuevo en unos segundos.');
-        if (import.meta.env?.DEV) {
-          console.error('Fallo al obtener posts recientes para la landing.', error);
-        }
-      }
-    };
-
-    fetchPosts();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [limit]);
-
-  const posts = useMemo(() => state.posts.slice(0, limit), [state.posts, limit]);
-  const isEmpty = !state.loading && posts.length === 0;
+function LatestPosts({ limit = FALLBACK_LIMIT, posts = [], loading = false }) {
+  const displayedPosts = useMemo(
+    () => (Array.isArray(posts) ? posts.slice(0, limit) : []),
+    [posts, limit]
+  );
+  const skeletonCount = Math.max(
+    Number.isFinite(Number(limit)) ? Math.trunc(Number(limit)) : 0,
+    FALLBACK_LIMIT
+  );
+  const isEmpty = !loading && displayedPosts.length === 0;
 
   return (
     <section className="mx-auto max-w-6xl px-4">
@@ -77,61 +42,84 @@ function LatestPosts({ limit = FALLBACK_LIMIT }) {
         variants={fadeInUp}
         className="mx-auto max-w-3xl text-center"
       >
-        <span className="text-sm font-semibold uppercase tracking-wide text-sky-500">Últimas publicaciones</span>
-        <h2 className="mt-4 text-3xl font-black tracking-tight text-slate-900 sm:text-4xl dark:text-white">
-          <Balancer>Tendencias en frontend moderno y buenas prácticas de DX</Balancer>
-        </h2>
-        <p className="mt-4 text-lg leading-relaxed text-slate-600 dark:text-slate-300">
-          <Balancer>
-            Descubre guías con código listo, análisis de herramientas y consejos para crear experiencias de usuario memorables en
-            React.
-          </Balancer>
-        </p>
+        {loading ? (
+          <SectionHeadingSkeleton />
+        ) : (
+          <>
+            <span className="text-sm font-semibold uppercase tracking-wide text-sky-500">
+              Últimas publicaciones
+            </span>
+            <h2 className="mt-4 text-3xl font-black tracking-tight text-slate-900 sm:text-4xl dark:text-white">
+              <Balancer>Tendencias en frontend moderno y buenas prácticas de DX</Balancer>
+            </h2>
+            <p className="mt-4 text-lg leading-relaxed text-slate-600 dark:text-slate-300">
+              <Balancer>
+                Descubre guías con código listo, análisis de herramientas y consejos para crear experiencias de usuario memorables en
+                React.
+              </Balancer>
+            </p>
+          </>
+        )}
       </motion.div>
 
-      <motion.div
-        {...inViewProps(0.2)}
-        variants={createStagger(0.14, 0.2)}
-        className="mt-12 grid gap-6 md:grid-cols-2 xl:grid-cols-3"
-      >
-        {state.loading
-          ? Array.from({ length: Math.max(3, limit) }).map((_, index) => <SkeletonCard key={index} index={index} />)
-          : posts.map((post) => (
-              <motion.article
-                key={post.slug ?? post.id ?? `post-${post.title}`}
-                variants={fadeInUp}
-                whileHover={hoverLift.whileHover}
-                whileTap={hoverLift.whileTap}
-                className="group relative flex flex-col overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-sm transition-all hover:-translate-y-1 hover:shadow-lg dark:border-slate-800 dark:bg-slate-900"
+      {loading ? (
+        <PostsGridSkeleton count={skeletonCount} />
+      ) : (
+        <motion.div
+          {...inViewProps(0.2)}
+          variants={createStagger(0.14, 0.2)}
+          className="mt-12 grid gap-6 md:grid-cols-2 xl:grid-cols-3"
+        >
+          {displayedPosts.map((post) => (
+            <motion.article
+              key={post.slug ?? post.id ?? `post-${post.title}`}
+              variants={fadeInUp}
+              whileHover={hoverLift.whileHover}
+              whileTap={hoverLift.whileTap}
+              className="group relative flex flex-col overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-sm transition-all hover:-translate-y-1 hover:shadow-lg dark:border-slate-800 dark:bg-slate-900"
+            >
+              <Link
+                to={`/post/${post.slug}`}
+                className="relative block overflow-hidden"
+                aria-label={`Leer ${post.title}`}
               >
-                <Link to={`/post/${post.slug}`} className="relative block overflow-hidden" aria-label={`Leer ${post.title}`}>
-                  <img
-                    src={getPostImage({ image: post.image, slug: post.slug ?? post.id, width: 640, height: 360 })}
-                    alt={post.imageAlt ?? `Imagen ilustrativa para ${post.title}`}
-                    loading="lazy"
-                    className="h-48 w-full object-cover transition-transform duration-500 group-hover:scale-105"
-                  />
-                  <div className="absolute inset-0 bg-gradient-to-t from-black/40 via-transparent to-transparent opacity-0 transition-opacity duration-500 group-hover:opacity-100" />
-                </Link>
-                <div className="flex flex-1 flex-col p-6">
-                  <p className="text-sm font-medium uppercase tracking-wide text-sky-500">
-                    {post.categories?.[0] ?? 'Blog'}
-                  </p>
-                  <h3 className="mt-3 text-xl font-semibold text-slate-900 transition-colors group-hover:text-sky-600 dark:text-white dark:group-hover:text-sky-300">
-                    <Link to={`/post/${post.slug}`}>
-                      <span className="absolute inset-0" aria-hidden="true" />
-                      {post.title}
-                    </Link>
-                  </h3>
-                  <p className="mt-3 text-base leading-relaxed text-slate-600 dark:text-slate-300">{post.excerpt ?? post.summary}</p>
-                  <div className="mt-6 flex items-center justify-between text-sm text-slate-500 dark:text-slate-400">
-                    <span>{post.author?.name ?? 'Equipo Codex'}</span>
-                    <time dateTime={post.created_at ?? post.publishedAt}>{formatDate(post.created_at ?? post.publishedAt)}</time>
-                  </div>
+                <img
+                  src={getPostImage({
+                    image: post.image,
+                    slug: post.slug ?? post.id,
+                    width: 640,
+                    height: 360
+                  })}
+                  alt={post.imageAlt ?? `Imagen ilustrativa para ${post.title}`}
+                  loading="lazy"
+                  className="h-48 w-full object-cover transition-transform duration-500 group-hover:scale-105"
+                />
+                <div className="absolute inset-0 bg-gradient-to-t from-black/40 via-transparent to-transparent opacity-0 transition-opacity duration-500 group-hover:opacity-100" />
+              </Link>
+              <div className="flex flex-1 flex-col p-6">
+                <p className="text-sm font-medium uppercase tracking-wide text-sky-500">
+                  {post.categories?.[0] ?? 'Blog'}
+                </p>
+                <h3 className="mt-3 text-xl font-semibold text-slate-900 transition-colors group-hover:text-sky-600 dark:text-white dark:group-hover:text-sky-300">
+                  <Link to={`/post/${post.slug}`}>
+                    <span className="absolute inset-0" aria-hidden="true" />
+                    {post.title}
+                  </Link>
+                </h3>
+                <p className="mt-3 text-base leading-relaxed text-slate-600 dark:text-slate-300">
+                  {post.excerpt ?? post.summary}
+                </p>
+                <div className="mt-6 flex items-center justify-between text-sm text-slate-500 dark:text-slate-400">
+                  <span>{post.author?.name ?? 'Equipo Codex'}</span>
+                  <time dateTime={post.created_at ?? post.publishedAt}>
+                    {formatDate(post.created_at ?? post.publishedAt)}
+                  </time>
                 </div>
-              </motion.article>
-            ))}
-      </motion.div>
+              </div>
+            </motion.article>
+          ))}
+        </motion.div>
+      )}
 
       {isEmpty ? (
         <div className="mt-12 rounded-3xl border border-dashed border-slate-300 bg-white/60 p-10 text-center text-slate-500 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-300">

--- a/frontend/src/components/skeleton/HeroSkeleton.jsx
+++ b/frontend/src/components/skeleton/HeroSkeleton.jsx
@@ -1,0 +1,39 @@
+import Skeleton from './Skeleton.jsx';
+import { cn } from '../../lib/utils.js';
+
+function HeroSkeleton({ className }) {
+  return (
+    <section
+      role="status"
+      aria-live="polite"
+      aria-label="Cargando contenido destacado"
+      className={cn(
+        'relative isolate overflow-hidden rounded-3xl border border-slate-200 bg-gradient-to-b from-gray-50 to-white px-6 py-20 shadow-sm transition-colors duration-500 dark:border-slate-800 dark:from-gray-900 dark:to-gray-950 sm:px-10 lg:px-16',
+        className
+      )}
+    >
+      <div
+        className="pointer-events-none absolute inset-0 -z-10 before:absolute before:inset-0 before:bg-[radial-gradient(ellipse_at_top,_rgba(255,255,255,0.25),_transparent_60%)] before:content-[''] dark:before:bg-[radial-gradient(ellipse_at_top,_rgba(0,0,0,0.35),_transparent_60%)]"
+        aria-hidden="true"
+      />
+      <div className="relative mx-auto flex max-w-6xl flex-col-reverse items-center gap-14 lg:flex-row lg:items-center lg:justify-between">
+        <div className="flex w-full max-w-2xl flex-col items-center gap-6 text-center lg:items-start lg:text-left">
+          <Skeleton as="span" className="h-9 w-48 rounded-full" />
+          <Skeleton as="h1" className="h-12 w-full rounded-2xl sm:h-14" />
+          <Skeleton as="p" className="h-4 w-full rounded-full" />
+          <Skeleton as="p" className="h-4 w-5/6 rounded-full" />
+          <div className="mt-4 flex w-full flex-col items-center gap-4 sm:flex-row sm:justify-center lg:justify-start">
+            <Skeleton className="h-12 w-full rounded-full sm:w-44" />
+            <Skeleton className="h-12 w-full rounded-full sm:w-40" />
+          </div>
+        </div>
+        <div className="relative w-full max-w-xl">
+          <Skeleton className="aspect-[5/3] w-full rounded-3xl border border-slate-200/80 shadow-2xl ring-1 ring-slate-900/10 dark:border-slate-700/60 dark:bg-slate-900/30 dark:ring-slate-50/10" />
+        </div>
+      </div>
+      <span className="sr-only">Cargando contenido destacado...</span>
+    </section>
+  );
+}
+
+export default HeroSkeleton;

--- a/frontend/src/components/skeleton/PostCardSkeleton.jsx
+++ b/frontend/src/components/skeleton/PostCardSkeleton.jsx
@@ -1,0 +1,39 @@
+import Skeleton from './Skeleton.jsx';
+import { cn } from '../../lib/utils.js';
+
+function PostCardSkeleton({ className }) {
+  return (
+    <article
+      className={cn(
+        'relative flex h-full flex-col overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900',
+        className
+      )}
+      aria-hidden="true"
+    >
+      <Skeleton className="aspect-[16/9] w-full rounded-none rounded-t-3xl" />
+      <div className="flex flex-1 flex-col gap-4 p-6">
+        <Skeleton className="h-4 w-24 rounded-full" />
+        <Skeleton as="h3" className="h-6 w-4/5 rounded-2xl" />
+        <div className="space-y-3">
+          <Skeleton as="p" className="h-4 w-full rounded-full" />
+          <Skeleton as="p" className="h-4 w-5/6 rounded-full" />
+          <Skeleton as="p" className="h-4 w-3/4 rounded-full" />
+        </div>
+        <div className="flex flex-wrap gap-2 pt-2">
+          <Skeleton className="h-7 w-20 rounded-full" />
+          <Skeleton className="h-7 w-16 rounded-full" />
+          <Skeleton className="h-7 w-24 rounded-full" />
+        </div>
+        <div className="mt-auto flex items-center justify-between pt-2">
+          <Skeleton className="h-4 w-24 rounded-full" />
+          <Skeleton className="h-4 w-20 rounded-full" />
+        </div>
+        <div className="pt-4">
+          <Skeleton className="h-11 w-32 rounded-full" />
+        </div>
+      </div>
+    </article>
+  );
+}
+
+export default PostCardSkeleton;

--- a/frontend/src/components/skeleton/PostsGridSkeleton.jsx
+++ b/frontend/src/components/skeleton/PostsGridSkeleton.jsx
@@ -1,0 +1,22 @@
+import PostCardSkeleton from './PostCardSkeleton.jsx';
+import { cn } from '../../lib/utils.js';
+
+function PostsGridSkeleton({ count = 6, className }) {
+  const safeCount = Number.isFinite(Number(count)) ? Math.max(1, Math.trunc(Number(count))) : 6;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-label="Cargando publicaciones recientes"
+      className={cn('mt-12 grid gap-6 md:grid-cols-2 xl:grid-cols-3', className)}
+    >
+      <span className="sr-only">Cargando publicaciones recientes...</span>
+      {Array.from({ length: safeCount }).map((_, index) => (
+        <PostCardSkeleton key={`post-skeleton-${index}`} />
+      ))}
+    </div>
+  );
+}
+
+export default PostsGridSkeleton;

--- a/frontend/src/components/skeleton/SectionHeadingSkeleton.jsx
+++ b/frontend/src/components/skeleton/SectionHeadingSkeleton.jsx
@@ -1,0 +1,14 @@
+import Skeleton from './Skeleton.jsx';
+import { cn } from '../../lib/utils.js';
+
+function SectionHeadingSkeleton({ className }) {
+  return (
+    <div className={cn('mx-auto max-w-3xl space-y-4 text-center', className)} aria-hidden="true">
+      <Skeleton as="span" className="mx-auto block h-3 w-40 rounded-full" />
+      <Skeleton as="h2" className="mx-auto h-10 w-3/4 rounded-2xl" />
+      <Skeleton as="p" className="mx-auto h-4 w-full max-w-2xl rounded-full" />
+    </div>
+  );
+}
+
+export default SectionHeadingSkeleton;

--- a/frontend/src/components/skeleton/Skeleton.jsx
+++ b/frontend/src/components/skeleton/Skeleton.jsx
@@ -1,0 +1,61 @@
+import { forwardRef, useEffect, useState } from 'react';
+import { cn } from '../../lib/utils.js';
+import { prefersReducedMotion } from '../../lib/motion-prefs.js';
+
+const Skeleton = forwardRef(function Skeleton(
+  { as: Component = 'div', className, ...rest },
+  ref
+) {
+  const [reducedMotion, setReducedMotion] = useState(() => prefersReducedMotion());
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return undefined;
+    }
+
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+    const handleChange = (event) => {
+      setReducedMotion(event.matches);
+    };
+
+    if (typeof mediaQuery.addEventListener === 'function') {
+      mediaQuery.addEventListener('change', handleChange);
+    } else if (typeof mediaQuery.addListener === 'function') {
+      mediaQuery.addListener(handleChange);
+    }
+
+    return () => {
+      if (typeof mediaQuery.removeEventListener === 'function') {
+        mediaQuery.removeEventListener('change', handleChange);
+      } else if (typeof mediaQuery.removeListener === 'function') {
+        mediaQuery.removeListener(handleChange);
+      }
+    };
+  }, []);
+
+  const props = { ...rest };
+  const ariaHidden = Object.prototype.hasOwnProperty.call(props, 'aria-hidden')
+    ? props['aria-hidden']
+    : true;
+
+  if (Object.prototype.hasOwnProperty.call(props, 'aria-hidden')) {
+    delete props['aria-hidden'];
+  }
+
+  return (
+    <Component
+      ref={ref}
+      data-reduced-motion={reducedMotion ? 'true' : 'false'}
+      className={cn(
+        'relative isolate overflow-hidden rounded-xl bg-gray-200 dark:bg-gray-800',
+        !reducedMotion && 'skeleton-shimmer',
+        className
+      )}
+      aria-hidden={ariaHidden}
+      {...props}
+    />
+  );
+});
+
+export default Skeleton;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -30,3 +30,51 @@
     @apply transition-colors duration-300;
   }
 }
+
+@keyframes shimmer {
+  0% {
+    background-position: -200% 0;
+  }
+
+  100% {
+    background-position: 200% 0;
+  }
+}
+
+.skeleton-shimmer::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background-image: linear-gradient(
+    90deg,
+    rgba(255, 255, 255, 0),
+    rgba(255, 255, 255, 0.6),
+    rgba(255, 255, 255, 0)
+  );
+  background-size: 200% 100%;
+  background-repeat: no-repeat;
+  animation: shimmer 1.5s infinite;
+  opacity: 0.6;
+}
+
+.dark .skeleton-shimmer::after {
+  background-image: linear-gradient(
+    90deg,
+    rgba(15, 23, 42, 0),
+    rgba(148, 163, 184, 0.4),
+    rgba(15, 23, 42, 0)
+  );
+}
+
+.skeleton-shimmer[data-reduced-motion='true']::after {
+  animation: none;
+  opacity: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skeleton-shimmer::after {
+    animation: none;
+    opacity: 0;
+  }
+}

--- a/frontend/src/lib/motion-prefs.js
+++ b/frontend/src/lib/motion-prefs.js
@@ -1,0 +1,14 @@
+export function prefersReducedMotion() {
+  try {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return false;
+    }
+
+    return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  } catch (error) {
+    if (import.meta.env?.DEV) {
+      console.warn('No se pudo evaluar prefers-reduced-motion.', error);
+    }
+    return false;
+  }
+}

--- a/frontend/src/pages/Landing.jsx
+++ b/frontend/src/pages/Landing.jsx
@@ -1,16 +1,91 @@
+import { useEffect, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
+import { toast } from 'sonner';
 import Hero from '../components/landing/Hero.jsx';
 import FeatureGrid from '../components/landing/FeatureGrid.jsx';
 import LatestPosts from '../components/landing/LatestPosts.jsx';
 import CTA from '../components/landing/CTA.jsx';
 import NewsletterForm from '../components/landing/NewsletterForm.jsx';
+import { listLatestPosts } from '../services/api.js';
 import { buildPageTitle, sanitizeMetaText, SITE_DESCRIPTION } from '../seo/config.js';
 
 const PAGE_TITLE = 'Inicio';
 const PAGE_DESCRIPTION =
   'Descubre recursos, tutoriales y patrones de diseño para crear experiencias modernas con React, Tailwind, Flowbite y Radix.';
+const LATEST_POSTS_LIMIT = 6;
+const MIN_LOADING_DURATION = 260;
 
 function Landing() {
+  const [latestPostsState, setLatestPostsState] = useState({
+    posts: [],
+    loading: true,
+    error: null
+  });
+
+  useEffect(() => {
+    let isMounted = true;
+    let timeoutId;
+
+    const loadLatestPosts = async () => {
+      const startTime =
+        typeof performance !== 'undefined' && typeof performance.now === 'function'
+          ? performance.now()
+          : Date.now();
+
+      setLatestPostsState((previous) => ({ ...previous, loading: true, error: null }));
+
+      const ensureMinimumDelay = (callback) => {
+        const now =
+          typeof performance !== 'undefined' && typeof performance.now === 'function'
+            ? performance.now()
+            : Date.now();
+        const elapsed = now - startTime;
+        const remaining = MIN_LOADING_DURATION - elapsed;
+
+        if (remaining > 0) {
+          timeoutId = setTimeout(callback, remaining);
+        } else {
+          callback();
+        }
+      };
+
+      try {
+        const results = await listLatestPosts({ limit: LATEST_POSTS_LIMIT });
+
+        ensureMinimumDelay(() => {
+          if (!isMounted) {
+            return;
+          }
+          setLatestPostsState({
+            posts: Array.isArray(results) ? results : [],
+            loading: false,
+            error: null
+          });
+        });
+      } catch (error) {
+        ensureMinimumDelay(() => {
+          if (!isMounted) {
+            return;
+          }
+          setLatestPostsState({ posts: [], loading: false, error: error ?? new Error('Unknown error') });
+          toast.error('No pudimos cargar las publicaciones recientes. Intenta de nuevo en unos segundos.');
+          if (import.meta.env?.DEV) {
+            console.error('Fallo al obtener posts recientes para la landing.', error);
+          }
+        });
+      }
+    };
+
+    loadLatestPosts();
+
+    return () => {
+      isMounted = false;
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+    };
+  }, []);
+
   return (
     <>
       <Helmet>
@@ -24,7 +99,11 @@ function Landing() {
       <div className="flex flex-col gap-24 pb-24">
         <Hero />
         <FeatureGrid />
-        <LatestPosts limit={6} />
+        <LatestPosts
+          limit={LATEST_POSTS_LIMIT}
+          loading={latestPostsState.loading}
+          posts={latestPostsState.posts}
+        />
         <NewsletterForm />
         <CTA />
       </div>


### PR DESCRIPTION
## Summary
- add reusable skeleton building blocks with shimmer styles and reduced-motion support
- integrate hero and latest posts loading placeholders using the new skeleton components
- manage landing latest posts loading state and minimum delay for smoother transitions

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f62dc2f6a083279e3ab8deacff2897